### PR TITLE
Fix including nested directories

### DIFF
--- a/src/debugadapter.ts
+++ b/src/debugadapter.ts
@@ -371,6 +371,7 @@ export class DebugSessionClass extends DebugSession {
 
 			// Save args
 			const rootFolder = (vscode.workspace.workspaceFolders) ? vscode.workspace.workspaceFolders[0].uri.fsPath : '';
+			process.chdir(rootFolder);
 			Settings.Init(args, rootFolder);
 			Settings.CheckSettings();
 		}

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -539,8 +539,9 @@ export class LabelsClass {
 				const matchInclStart = /^[0-9a-f]+\s+include\s+\"([^\s]*)\"/i.exec(remainingLine);
 				if(matchInclStart) {
 					const fName = matchInclStart[1];
+					const dirName = stack[stack.length - 1].fileName.replace(/(^|\\|\/)[^\\\/]+$/, '$1');
 					const absFName = Utility.getAbsSourceFilePath(fName, sources);
-					const relFName = Utility.getRelFilePath(absFName);
+					const relFName = dirName + Utility.getRelFilePath(absFName);
 					stack.push({fileName: relFName, lineNr: 0});
 					index = stack.length-1;
 					expectedLine = undefined;


### PR DESCRIPTION
I might just be using it wrong, but I found I couldn't debug asm files in nested folders when running VSCode on Windows 10. VSCode would be looking in the wrong directory. So, here's a patch that fixes it.

Example project that fails to find the nested .asm files when stepping into code:
https://github.com/ryanw/dezog-bad-paths-example