### PR TITLE
[zsim] Support for not-populated slots

### DIFF
--- a/src/remotes/Paging/memorymodel.ts
+++ b/src/remotes/Paging/memorymodel.ts
@@ -67,20 +67,15 @@ export class MemoryModel {
 
 }
 
-
 /**
  * Class that takes care of the memory paging.
  * I.e. it defines which memory bank to slot association is used.
  *
  * Is the base class and defines:
  * 0000-3FFF: ROM
- * 4000-FFFF: RAM (or 4000-8000 on 16K models)
+ * 4000-7FFF: RAM
  */
-export class Zx48MemoryModel extends MemoryModel {
-
-	constructor(private readonly is16KModel?: boolean) {
-		super();
-	}
+ export class Zx16MemoryModel extends MemoryModel {
 
 	/**
 	 * Returns the standard description, I.e. 0-3FFF = ROM, rest is RAM.
@@ -89,19 +84,46 @@ export class Zx48MemoryModel extends MemoryModel {
 	 * and a name.
 	 */
 	public getMemoryBanks(slots: number[]|undefined): MemoryBank[] {
-		// Prepare array
-		if (this.is16KModel) {
-			return [
-				{start: 0x0000, end: 0x3FFF, name: "ROM"},
-				{start: 0x4000, end: 0x7FFF, name: "RAM"},
-				{start: 0x8000, end: 0xFFFF, name: "N/A"}
-			];
-		} else {
-			return [
-				{start: 0x0000, end: 0x3FFF, name: "ROM"},
-				{start: 0x4000, end: 0xFFFF, name: "RAM"}
-			];
-		}
+		return [
+			{start: 0x0000, end: 0x3FFF, name: "ROM"},
+			{start: 0x4000, end: 0x7FFF, name: "RAM"},
+			{start: 0x8000, end: 0xFFFF, name: "N/A"}
+		];
+	}
+
+
+	/**
+	 * Returns the bank size.
+	 * @returns 0 in this case = no banks used.
+	 */
+	public getBankSize() {
+		return 0;
+	}
+
+}
+
+
+/**
+ * Class that takes care of the memory paging.
+ * I.e. it defines which memory bank to slot association is used.
+ *
+ * Is the base class and defines:
+ * 0000-3FFF: ROM
+ * 4000-FFFF: RAM
+ */
+export class Zx48MemoryModel extends MemoryModel {
+
+	/**
+	 * Returns the standard description, I.e. 0-3FFF = ROM, rest is RAM.
+	 * @param slots Not used.
+	 * @returns An array with the available memory pages. Contains start and end address
+	 * and a name.
+	 */
+	public getMemoryBanks(slots: number[]|undefined): MemoryBank[] {
+		return [
+			{start: 0x0000, end: 0x3FFF, name: "ROM"},
+			{start: 0x4000, end: 0xFFFF, name: "RAM"}
+		];
 	}
 
 

--- a/src/remotes/Paging/memorymodel.ts
+++ b/src/remotes/Paging/memorymodel.ts
@@ -10,8 +10,8 @@ export interface MemoryBank {
 	/// Z80 end address of page.
 	end: number;
 
-	/// The name of the mapped memory area.
-	name: string;
+	/// The name of the mapped memory area. `N/A` stands for "not populated"
+	name: string | "N/A";
 };
 
 
@@ -74,9 +74,13 @@ export class MemoryModel {
  *
  * Is the base class and defines:
  * 0000-3FFF: ROM
- * 4000-FFFF: RAM
+ * 4000-FFFF: RAM (or 4000-8000 on 16K models)
  */
 export class Zx48MemoryModel extends MemoryModel {
+
+	constructor(private readonly is16KModel?: boolean) {
+		super();
+	}
 
 	/**
 	 * Returns the standard description, I.e. 0-3FFF = ROM, rest is RAM.
@@ -86,12 +90,18 @@ export class Zx48MemoryModel extends MemoryModel {
 	 */
 	public getMemoryBanks(slots: number[]|undefined): MemoryBank[] {
 		// Prepare array
-		const pages: Array<MemoryBank>=[
-		{start: 0x0000, end: 0x3FFF, name: "ROM"},
-		{start: 0x4000, end: 0xFFFF, name: "RAM"}
-		];
-		// Return
-		return pages;
+		if (this.is16KModel) {
+			return [
+				{start: 0x0000, end: 0x3FFF, name: "ROM"},
+				{start: 0x4000, end: 0x7FFF, name: "RAM"},
+				{start: 0x8000, end: 0xFFFF, name: "N/A"}
+			];
+		} else {
+			return [
+				{start: 0x0000, end: 0x3FFF, name: "ROM"},
+				{start: 0x4000, end: 0xFFFF, name: "RAM"}
+			];
+		}
 	}
 
 

--- a/src/remotes/remotebase.ts
+++ b/src/remotes/remotebase.ts
@@ -1322,7 +1322,7 @@ export class RemoteBase extends EventEmitter {
 
 	/**
 	 * Reads the slots/banks association.
-	 * @returns A Promise with a slot array containing the refernced banks or undefined if no slots are used.
+	 * @returns A Promise with a slot array containing the referenced banks or undefined if no slots are used.
 	 */
 	public getSlots(): number[] | undefined {
 		return Z80Registers.getSlots();

--- a/src/remotes/zsimulator/zsimremote.ts
+++ b/src/remotes/zsimulator/zsimremote.ts
@@ -14,7 +14,7 @@ import {Zx16Memory} from './zx16memory';
 import {Zx48Memory} from './zx48memory';
 import {GenericBreakpoint} from '../../genericwatchpoint';
 import {Z80RegistersStandardDecoder} from '../z80registersstandarddecoder';
-import {MemoryModel, Zx128MemoryModel, Zx48MemoryModel, ZxNextMemoryModel} from '../Paging/memorymodel';
+import {MemoryModel, Zx128MemoryModel, Zx16MemoryModel, Zx48MemoryModel, ZxNextMemoryModel} from '../Paging/memorymodel';
 import {SimulatedMemory} from './simmemory';
 import {Zx128Memory} from './zx128memory';
 import {ZxNextMemory} from './zxnextmemory';
@@ -305,7 +305,7 @@ export class ZSimRemote extends DzrpRemote {
 				{
 					// ZX 16K
 					// Memory Model
-					this.memoryModel = new Zx48MemoryModel(true);
+					this.memoryModel = new Zx16MemoryModel();
 					this.memory = new Zx16Memory();
 				}
 				break;

--- a/src/remotes/zsimulator/zsimremote.ts
+++ b/src/remotes/zsimulator/zsimremote.ts
@@ -10,6 +10,7 @@ import {MemBuffer} from '../../misc/membuffer';
 import {CodeCoverageArray} from './codecovarray';
 import {CpuHistoryClass, CpuHistory, DecodeStandardHistoryInfo} from '../cpuhistory';
 import {ZSimCpuHistory} from './zsimcpuhistory';
+import {Zx16Memory} from './zx16memory';
 import {Zx48Memory} from './zx48memory';
 import {GenericBreakpoint} from '../../genericwatchpoint';
 import {Z80RegistersStandardDecoder} from '../z80registersstandarddecoder';
@@ -298,6 +299,14 @@ export class ZSimRemote extends DzrpRemote {
 					// Memory Model
 					this.memoryModel = new MemoryModel();
 					this.memory = new SimulatedMemory(1, 1);
+				}
+				break;
+			case "ZX16K":
+				{
+					// ZX 16K
+					// Memory Model
+					this.memoryModel = new Zx48MemoryModel(true);
+					this.memory = new Zx16Memory();
 				}
 				break;
 			case "ZX48K":

--- a/src/remotes/zsimulator/zsimulationview.ts
+++ b/src/remotes/zsimulator/zsimulationview.ts
@@ -662,6 +662,9 @@ width:70px;
             position:absolute;
             text-align: center;
 		}
+		.disabled {
+			font-style: italic;
+		}
 		.slot {
 			height:2em;
 			background: gray
@@ -742,7 +745,8 @@ width:70px;
 				const bank = banks[i];
 				const pos = bank.start * 100 / 0x10000;
 				const width = (bank.end + 1 - bank.start) * 100 / 0x10000;
-				const add = `<div class="border" id="slot${i}_id" style="top:3.5em; left:${pos}%; width:${width}%; height: 2em">${bank.name}</div>
+				const classes = bank.name === "N/A" ? "border disabled" : "border";
+				const add = `<div class="${classes}" id="slot${i}_id" style="top:3.5em; left:${pos}%; width:${width}%; height: 2em">${bank.name}</div>
 			`;
 				html += add;
 			}

--- a/src/remotes/zsimulator/zx16memory.ts
+++ b/src/remotes/zsimulator/zx16memory.ts
@@ -1,0 +1,31 @@
+import {SimulatedMemory} from './simmemory';
+import * as fs from 'fs';
+import {Utility} from '../../misc/utility';
+
+
+
+/**
+ * Represents the memory of a ZX 16k.
+ * Especially sets the ROM area.
+ */
+export class Zx16Memory extends SimulatedMemory {
+
+	/// Constructor.
+	constructor() {
+		super(4, 4);
+		// 0000-0x3FFF is ROM
+		this.romBanks[0] = true;
+		// Load ROMs
+		const romFilePath = Utility.getExtensionPath() + '/data/48.rom';
+		const romBuffer = fs.readFileSync(romFilePath);
+		const size = 0x4000;
+		const rom = new Uint8Array(romBuffer.buffer, 0, size);
+		this.writeBank(0, rom);
+
+		// 8000-0xFFFF is not populated, read as 0xFF (floating bus)
+		this.setAsNotPopulatedSlot(2);
+		this.setAsNotPopulatedSlot(3);
+	}
+
+}
+

--- a/src/remotes/zsimulator/zx16memory.ts
+++ b/src/remotes/zsimulator/zx16memory.ts
@@ -23,8 +23,8 @@ export class Zx16Memory extends SimulatedMemory {
 		this.writeBank(0, rom);
 
 		// 8000-0xFFFF is not populated, read as 0xFF (floating bus)
-		this.setAsNotPopulatedSlot(2);
-		this.setAsNotPopulatedSlot(3);
+		this.setAsNotPopulatedBank(2);
+		this.setAsNotPopulatedBank(3);
 	}
 
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -173,10 +173,11 @@ export interface ZSimType {
 	// The sample rate used for audio. Defaults to 22050 Hz.
 	audioSampleRate: number,
 
-	// Memory model: ZX48k, ZX128K or ZXNext.
+	// Memory model: ZX16k, ZX48k, ZX128K or ZXNext.
 	// - "RAM": One memory area of 64K RAM, no banks.
-	// - "ZX48": ROM and RAM as of the ZX Spectrum 48K.
-	// - "ZX128": Banked memory as of the ZX Spectrum 48K (16k slots/banks).
+	// - "ZX16K": ROM and RAM as of the ZX Spectrum 16K.
+	// - "ZX48K": ROM and RAM as of the ZX Spectrum 48K.
+	// - "ZX128K": Banked memory as of the ZX Spectrum 48K (16k slots/banks).
 	// - "ZXNEXT": Banked memory as of the ZX Next (8k slots/banks).
 	memoryModel: string;
 

--- a/tests/zxmemory.tests.ts
+++ b/tests/zxmemory.tests.ts
@@ -3,10 +3,17 @@ import * as assert from 'assert';
 import {MemBuffer} from '../src/misc/membuffer';
 import {PagedMemory} from '../src/remotes/zsimulator/pagedmemory';
 
+// Simply publicly expose protected members
+class MemBufferInt extends MemBuffer {
+	public getReadOffset() {
+		return this.readOffset;
+	}
+}
+
 suite('PagedMemory', () => {
 	test('serialize/deserialize', () => {
-		let memBuffer;
-		let writeSize;
+		let memBuffer: MemBufferInt;
+		let writeSize: number;
 		{
 			const mem=new PagedMemory(8, 256);
 
@@ -37,7 +44,7 @@ suite('PagedMemory', () => {
 			writeSize=mem.getSerializedSize();
 
 			// Serialize
-			memBuffer=new MemBuffer(writeSize);
+			memBuffer=new MemBufferInt(writeSize);
 			mem.serialize(memBuffer);
 		}
 
@@ -46,7 +53,7 @@ suite('PagedMemory', () => {
 		rMem.deserialize(memBuffer);
 
 		// Check size
-		const readSize=(memBuffer as any).readOffset;
+		const readSize=memBuffer.getReadOffset();
 		assert.equal(writeSize, readSize);
 
 		// Test the slots/banks
@@ -147,5 +154,74 @@ suite('PagedMemory', () => {
 		assert.equal(0xEF01ABCD, result);
 	});
 
+
+	test('non populated slots', () => {
+		const mem=new PagedMemory(4, 8);
+		mem.setAsNotPopulatedSlot(2);
+		mem.setMemory8(0x7FFC, 1);
+		mem.setMemory8(0x7FFD, 2);
+		mem.setMemory8(0x7FFE, 3);
+		mem.setMemory8(0x7FFF, 4);
+
+		mem.setMemory8(0xC000, 5);
+		mem.setMemory8(0xC001, 6);
+		mem.setMemory8(0xC002, 7);
+		mem.setMemory8(0xC003, 8);
+
+		// Not populated
+		assert.equal(0xFF, mem.getMemory8(0x8000));
+		assert.equal(0xFF, mem.getMemory8(0xBFFF));
+
+		mem.setMemory8(0x8000, 42);
+		assert.equal(0xFF, mem.getMemory8(0x8000));
+		mem.write8(0x8000, 42);
+		assert.equal(0xFF, mem.getMemory8(0x8000));
+
+		// Test boundaries: byte read access
+		assert.equal(0x4, mem.getMemory8(0x7FFF));
+		assert.equal(0x5, mem.getMemory8(0xC000));
+
+		// Test boundaries: word read access
+		assert.equal(0x403, mem.getMemory16(0x7FFE));
+		assert.equal(0xFF04, mem.getMemory16(0x7FFF));
+		assert.equal(0xFFFF, mem.getMemory16(0x8000));
+		assert.equal(0xFFFF, mem.getMemory16(0xBFFE));
+		assert.equal(0x05FF, mem.getMemory16(0xBFFF));
+		assert.equal(0x0605, mem.getMemory16(0xC000));
+
+		// Test boundaries: dword read access
+		assert.equal(0x04030201, mem.getMemory32(0x7FFC));
+		assert.equal(0xFF040302, mem.getMemory32(0x7FFD));
+		assert.equal(0xFFFF0403, mem.getMemory32(0x7FFE));
+		assert.equal(0xFFFFFF04, mem.getMemory32(0x7FFF));
+		assert.equal(0xFFFFFFFF, mem.getMemory32(0x8000));
+		assert.equal(0xFFFFFFFF, mem.getMemory32(0xBFFC));
+		assert.equal(0x05FFFFFF, mem.getMemory32(0xBFFD));
+		assert.equal(0x0605FFFF, mem.getMemory32(0xBFFE));
+		assert.equal(0x070605FF, mem.getMemory32(0xBFFF));
+		assert.equal(0x08070605, mem.getMemory32(0xC000));
+
+		// Test boundaries: word write access
+		mem.setMemory16(0x7FFF, 0x0908);
+		assert.equal(0xFF08, mem.getMemory16(0x7FFF));
+		mem.setMemory16(0xBFFF, 0x0a0b);
+		assert.equal(0x0AFF, mem.getMemory16(0xBFFF));
+
+		// Test readBlock
+		let buffer = mem.readBlock(0x7FFE, 4);
+		assert.deepEqual([0x3, 0x8, 0xff, 0xff], Array.from(buffer));
+		buffer = mem.readBlock(0xBFFE, 4);
+		assert.deepEqual([0xff, 0xff, 0xA, 0x6], Array.from(buffer));
+
+		// Test writeBlock
+		mem.writeBlock(0x7FFE, Uint8Array.from([0x10, 0x11, 0x12, 0x13]));
+		mem.writeBlock(0xBFFE, Uint8Array.from([0x20, 0x21, 0x22, 0x23]));
+
+		// Bank underneath the not-populated slot (2) should have remained untouched
+		const flatMem = mem.getMemoryData();
+		for (let addr = 0x8000; addr < 0xC000; addr++) {
+			assert.equal(0, flatMem[addr]);
+		}
+	});
 });
 


### PR DESCRIPTION
Added support to simulated not-populated slots in hardware: read 0xFF (due to TTL levels) and can't write.
This will greatly help in simulating custom Z80 boards with partial memory, or with banked memories that doesn't cover the whole 16-bit addressing.

I've then added a new working ZX16K model with not-populated 2-3 slots. Now booting the machine will correctly set the RAMTOP system variable before 0x8000 (obviously the ROM is the same).

The not-populated slots will be rendered with a slanted "N/A" in the simulation view. CPU accesses to not-populated slots will be however be correctly reported as normal activity.

I would like initially to implemented the not-populated simply creating a bank full of 0xFF and making it as read-only (via `romBanks`). However I felt that implementing it at slot level would be more correct.
Once a slot is set as not-populated, it cannot be reverted. Setting a bank index in `slots` of a not-populated slot will have no effects.

To be sure that the debugger will correctly report 0xFF in the IDE, I realized that the `getMemory8/getMemory16/getMemory32`. `setMemory8/setMemory16`, `readBlock/writeBlock` would have fixed to reflect such state. Is that correct? In that case I slightly refactored it to simplify the implementation when reading words and blocks across slot boundaries.

Thanks for the great project, it is incredibly smooth to use, a must-have for retro-design new code for vintage hardware!

L
