### PR TITLE
Advanced declarative non-uniform bank paging

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"binary-file": "^0.2.3",
 		"gif-writer": "^0.9.4",
 		"glob": "^7.2.0",
+		"intel-hex": "^0.1.2",
 		"jsonc-parser": "^3.0.0",
 		"node-gzip": "^1.1.2",
 		"posthtml": "^0.16.5",

--- a/package.json
+++ b/package.json
@@ -322,18 +322,39 @@
 										"default": "RAM"
 									},
 									"customMemory": {
-										"description": "Only evaluated if 'memoryModel' is set to 'CUSTOM'. Chooses the banks and their memory types. Please refer to the documentation.",
-										"type": "object",
-										"properties": {
-											"numberOfBanks": {
-												"type": "number",
-												"description": "The number of banks to use for the 64k address space. Each bank is of the same size (64k/numberOfBanks).",
-												"default": 4
-											},
-											"banks": {
-												"description": "Bank number/memory type pairs. E.g. \"0\": \"ROM\". Allowed for the memory type are 'ROM', 'RAM' and 'UNUSED'. Any not mentioned bank will automatically get the 'UNUSED' type.",
-												"type": "object",
-												"properties": {}
+										"description": "Only evaluated if 'memoryModel' is set to 'CUSTOM'. Define the memory layout as list of ranges in the 64k addressing space.",
+										"type": "array",
+										"items": {
+											"type": "object",
+											"properties": {
+												"range": {
+													"type": "array",
+													"description": "Array of two elements: first and last address of the slot. Minimum slot size and granularity is 1Kb",
+													"items": {
+														"type": ["string", "number"]
+													}
+												},
+												"name": {
+													"description": "The optional slot name",
+													"type": "string"
+												},
+												"rom": {
+													"description": "Optional path to a ROM file (binary or hex)",
+													"type": "string"
+												},
+												"romOffset": {
+													"description": "Optional offset for the ROM file",
+													"type": ["string", "number"]
+												},
+												"banked": {
+													"type": "object",
+													"properties": {
+														"count": {
+															"type": "number",
+															"description": "Number of memory banks that can be mapped in the current slot"
+														}
+													}
+												}
 											}
 										},
 										"ulaScreen": {

--- a/package.json
+++ b/package.json
@@ -322,24 +322,24 @@
 										"default": "RAM"
 									},
 									"customMemory": {
-										"description": "Only evaluated if 'memoryModel' is set to 'CUSTOM'. Define the memory layout as list of ranges in the 64k addressing space.",
+										"description": "Only evaluated if 'memoryModel' is set to 'CUSTOM'. Define the memory layout as list of ranges (slots) in the 64k addressing space.",
 										"type": "array",
 										"items": {
 											"type": "object",
 											"properties": {
 												"range": {
 													"type": "array",
-													"description": "Array of two elements: first and last address of the slot. Minimum slot size and granularity is 1Kb",
+													"description": "Array of two elements: first and last address of the slot (inclusive). Minimum slot size and granularity is 1Kb",
 													"items": {
 														"type": ["string", "number"]
 													}
 												},
 												"name": {
-													"description": "The optional slot name",
+													"description": "Optional display name of the slot. If banked, it can be overridden by bank names",
 													"type": "string"
 												},
 												"rom": {
-													"description": "Optional path to a ROM file (binary or hex)",
+													"description": "Optional. If specified, set the slot as ROM. The content is the path of the ROM content. File content should be in raw format (i.e. `.rom` and `.bin` extensions) or Intel HEX 8-bit format (`.hex` extensions). Array content is flat and it should cover the whole bank span (if banked).",
 													"type": "string"
 												},
 												"romOffset": {
@@ -347,11 +347,44 @@
 													"type": ["string", "number"]
 												},
 												"banked": {
+													"description": "If set, enables banking on such slot",
 													"type": "object",
 													"properties": {
 														"count": {
 															"type": "number",
 															"description": "Number of memory banks that can be mapped in the current slot"
+														},
+														"names": {
+															"type": "array",
+															"description": "Optional display names of the banks",
+															"items": {
+																"type": "string"
+															}
+														},
+														"ioMmu": {
+															"type": "object",
+															"description": "Description of Memory management unit (bank switcher) accessed via single I/O port",
+															"properties": {
+																"port": {
+																	"type": ["number", "string", "object"],
+																	"description": "The I/O port that control the banks (full 16-bit address). If an object, `mask` is a 16-bit mask to filter the current address (mask to 1), and `match` is the address match of the result mask.",
+																	"properties": {
+																		"mask": {
+																			"type": ["number", "string"]
+																		},
+																		"match": {
+																			"type": ["number", "string"]
+																		}
+																	}
+																},
+																"bitMap": {
+																	"description": "List of the bit number (b0 to b7) of the port data value to forms the selected bank ID",
+																	"type": "array",
+																	"items": {
+																		"type": "number"
+																	}
+																}
+															}
 														}
 													}
 												}

--- a/src/custommemorysettings.ts
+++ b/src/custommemorysettings.ts
@@ -68,10 +68,10 @@ export interface CustomMemorySettings {
  * Return the MMU handler
  */
 const getMmuHandler = (mmu: CustomMemoryMmuInfo): ((ioPort: number, dataValue: number) => number) => {
-	const decodeBankBits = (byte: number, bitmap: number[]): number => {
+	const decodeBankBits = (byte: number, dataBits: number[]): number => {
 		let ret = 0;
-		for (let b = 0, val = 1; b < bitmap.length; b++, val <<= 1) {
-			const mask = 1 << bitmap[b];
+		for (let b = 0, val = 1; b < dataBits.length; b++, val <<= 1) {
+			const mask = 1 << dataBits[b];
 			if (byte & mask) {
 				ret += val;
 			}
@@ -90,7 +90,7 @@ const getMmuHandler = (mmu: CustomMemoryMmuInfo): ((ioPort: number, dataValue: n
 	return (port, value) => {
 		if ((port & mask) === match) {
 			// Address decoded. Now decode the data bus bits
-			return decodeBankBits(value, mmu.bitMap);
+			return decodeBankBits(value, mmu.dataBits);
 		} else {
 			return -1;
 		}

--- a/src/custommemorysettings.ts
+++ b/src/custommemorysettings.ts
@@ -1,0 +1,214 @@
+import { CustomMemoryBankInfo, CustomMemoryMmuInfo, CustomMemorySlot as settings_CustomMemorySlot, CustomMemoryType, HexNumber } from './settings';
+import { Utility } from './misc/utility';
+import * as path from 'path';
+import * as fs from 'fs';
+import { BankType } from './remotes/zsimulator/simmemory';
+
+const toNumber = (hex: HexNumber): number => {
+	return typeof hex === "string" ? Utility.parseValue(hex) : hex;
+};
+
+const readHexFromFile = (filePath: string): Uint8Array => {
+	const { data }: { data: Buffer } = require("intel-hex").parse(fs.readFileSync(filePath));
+	return new Uint8Array(data);
+}
+
+const readRomFile = (filePath: string): Uint8Array => {
+	switch (path.extname(filePath).toLowerCase()) {
+	case ".hex":
+		return readHexFromFile(filePath);
+	case ".bin":
+	case ".rom":
+		const romBuffer = fs.readFileSync(filePath);
+		return new Uint8Array(romBuffer.buffer);
+	default:
+		throw new Error(`Unknown ROM extension file: ${filePath}`);
+	}
+}
+
+export interface CustomMemorySlotBankInfo extends Omit<CustomMemoryBankInfo, "ioMmu"> {
+	/**
+	 * Decodes the current I/O write operation. If port matches the mask (full 16-bit address bus),
+	 * use the data bus value to calculate the raw bank number.
+	 * If port mask doesn't match, return negative value.
+	 */
+	mmuHandler?: ((ioPort: number, dataValue: number) => number)
+};
+
+export interface CustomMemorySlot {
+	// First address
+	begin: number;
+	// Slot size
+	size: number;
+	// RAM, ROM or not populated
+	type: BankType;
+	// decoded ROM image
+	rom?: Uint8Array;
+	// decoded ROM offset
+	romOffset?: number;
+	// Id of the first bank ID in the uniform slot system
+	firstBankIdx: number;
+	// Id of the first slot ID in the uniform slot system
+	firstSlotIdx: number;
+	// Slot name
+	name?: string;
+	// Bank information
+	bankInfo: CustomMemorySlotBankInfo;
+}
+
+export interface CustomMemorySettings {
+	uniformSlotSize: number;
+	uniformBankCount: number;
+	unusedBankIdx: number;
+
+	slots: CustomMemorySlot[];
+}
+
+/**
+ * Return the MMU handler
+ */
+const getMmuHandler = (mmu: CustomMemoryMmuInfo): ((ioPort: number, dataValue: number) => number) => {
+	const decodeBankBits = (byte: number, bitmap: number[]): number => {
+		let ret = 0;
+		for (let b = 0, val = 1; b < bitmap.length; b++, val <<= 1) {
+			const mask = 1 << bitmap[b];
+			if (byte & mask) {
+				ret += val;
+			}
+		}
+		return ret;
+	};
+
+	let match: number;
+	let mask: number = 0xffff;
+	if (typeof mmu.port === "number" || typeof mmu.port === "string") {
+		match = toNumber(mmu.port);
+	} else {
+		match = toNumber(mmu.port.match);
+		mask = toNumber(mmu.port.mask);
+	}
+	return (port, value) => {
+		if ((port & mask) === match) {
+			// Address decoded. Now decode the data bus bits
+			return decodeBankBits(value, mmu.bitMap);
+		} else {
+			return -1;
+		}
+	};
+}
+
+export const toCustomMemorySettings = (memType: CustomMemoryType): CustomMemorySettings => {
+	interface SlotInfo extends Omit<settings_CustomMemorySlot, "range"> {
+		// First address
+		begin: number;
+		// Last address
+		end: number;
+		// Size in bytes
+		size: number;
+		// RAM, ROM or not populated
+		type: BankType;
+		// decoded ROM image
+		rom?: Uint8Array;
+		// Id of the first bank ID in the uniform page
+		firstBankIdx?: number;
+		// Id of the first slot ID in the uniform slot system
+		firstSlotIdx?: number;
+		// Bank information
+		bankInfo: CustomMemoryBankInfo
+	}
+
+	// Expand properties of the slot info, decoding the input
+	let slots: SlotInfo[] = memType.map((slot, i) => {
+		const begin = toNumber(slot.range[0]);
+		const end = toNumber(slot.range[1]);
+		const size = end - begin + 1;
+
+		Utility.assert((size % 1024) === 0, `Slot ${i} size not multiple of 1K`);
+		Utility.assert(begin >= 0 && end < 0x10000, "Slot out of 16-bit addressing space");
+
+		let rom = slot.rom;
+		if (typeof slot.rom === "string") {
+			rom = readRomFile(slot.rom);
+		}
+		const bankInfo: CustomMemorySlotBankInfo = slot.banked || { count: 1 };
+		if (slot.banked && slot.banked.ioMmu) {
+			// MMU controlled by single I/O port
+			bankInfo.mmuHandler = getMmuHandler(slot.banked.ioMmu);
+		}
+		return {
+			...slot,
+			begin,
+			end,
+			size,
+			name: slot.name,
+			type: rom ? BankType.ROM : BankType.RAM,
+			bankInfo,
+			rom: rom as Uint8Array,
+			romOffset: toNumber(slot.romOffset || 0),
+		};
+	});
+
+	// Check overlapping and fill the not populated spaces
+	slots = slots.reduce((list, slot, i) => {
+		list.push(slot);
+		if (i > 0) {
+			Utility.assert(slot.begin > slots[i - 1].end, `Slots ${i - 1} and ${i} are overlapping or out-of order`);
+		}
+		if (i < slots.length - 1) {
+			Utility.assert(slot.end < slots[i + 1].begin, `Slots ${i} and ${i + 1} are overlapping or out-of order`);
+			if (slot.end + 1 < slots[i + 1].begin) {
+				// Fill unpopulated slot with a gap
+				list.push({
+					begin: slot.end + 1,
+					end: slots[i + 1].begin - 1,
+					type: BankType.UNUSED,
+					size: slots[i + 1].begin - slot.end - 1,
+					bankInfo: { count: 1 }
+				});
+			}
+		} else {
+			if (slot.end < 0xffff) {
+				// Fill unpopulated slot
+				list.push({
+					begin: slot.end + 1,
+					end: 0xffff,
+					type: BankType.UNUSED,
+					size: 0x10000 - slot.end - 1,
+					bankInfo: { count: 1 }
+				});
+			}
+		}
+		return list;
+	}, [] as SlotInfo[]);
+
+	// Calc minimum uniform slot count
+	const uniformSlotSize = Math.min(...slots.map(slot => slot.size));
+
+	// Calc total bank count (in uniform slot size)
+	let bankCounter = 0;
+	let slotCounter = 0;
+	let unusedBankIdx = -1;
+	slots.forEach(slot => {
+		const uniformSlotCount = slot.size / uniformSlotSize;
+		slot.firstSlotIdx = slotCounter;
+		slotCounter += uniformSlotCount;
+
+		if (slot.type !== BankType.UNUSED) {
+			slot.firstBankIdx = bankCounter;
+			bankCounter += uniformSlotCount * slot.bankInfo.count;
+		} else {
+			if (unusedBankIdx < 0) {
+				unusedBankIdx = bankCounter;
+				bankCounter++;
+			}
+			slot.firstBankIdx = unusedBankIdx;
+		}
+	});
+
+	return {
+		slots: slots as CustomMemorySlot[],
+		uniformSlotSize,
+		uniformBankCount: bankCounter,
+		unusedBankIdx,
+	};
+}

--- a/src/remotes/Paging/memorymodel.ts
+++ b/src/remotes/Paging/memorymodel.ts
@@ -1,6 +1,7 @@
 import {Z80Registers} from "../z80registers";
 import { CustomMemorySettings } from "../../custommemorysettings";
 import { BankType } from "../zsimulator/simmemory";
+import { CustomMemory } from "../zsimulator/custommemory";
 
 
 
@@ -296,7 +297,7 @@ export class CustomMemoryModel extends MemoryModel {
 	 * Constructor.
 	 * @param customMemory The memory description.
 	 */
-	constructor(private readonly info: CustomMemorySettings) {
+	constructor(private readonly info: CustomMemorySettings, private readonly customMemory?: CustomMemory) {
 		super();
 	}
 
@@ -307,6 +308,7 @@ export class CustomMemoryModel extends MemoryModel {
 	 * and a name.
 	 */
 	public getMemoryBanks(slots: number[] | undefined): MemoryBank[] {
+		slots = slots || (this.customMemory && this.customMemory.getSlots());
 		return this.info.slots.map(slot => {
 			let name = slot.name;
 			if (!name) {

--- a/src/remotes/zsimulator/custommemory.ts
+++ b/src/remotes/zsimulator/custommemory.ts
@@ -1,34 +1,207 @@
-import {BankType, SimulatedMemory} from './simmemory';
-import {CustomMemoryType} from '../../settings';
+import { BankType, SimulatedMemory } from './simmemory';
+import { MemoryBank, MemoryModel } from '../Paging/memorymodel';
+import { HexNumber, CustomMemoryType, ZSimCustomMemorySlot } from '../../settings';
+import { Utility } from '../../misc/utility';
+import { Z80Ports } from './z80ports';
+import * as path from 'path';
+import * as fs from 'fs';
 
+const toNumber = (hex: HexNumber): number => {
+	return Utility.parseValue(hex.toString());
+};
 
+interface SlotInfo extends Omit<ZSimCustomMemorySlot, "range"> {
+	begin: number;
+	end: number;
+	size: number;
+	sizeInPages: number;
+	populated?: boolean;
+	bankCount: number;
+	firstBank: number;
+}
 
-/**
- * Takes the custom memory model description and creates a memory out of it.
- */
-export class CustomMemory extends SimulatedMemory {
+export interface SlottedMemoryInfo {
+	bankSize: number;
+	bankCount: number;
+	slots: SlotInfo[];
+	slotSize: number;
+	notPopulatedBank: number;
+}
 
-	/**
-	 * Constructor.
-	 * @param customMemory The memory description.
-	 */
-	constructor(customMemory: CustomMemoryType) {
-		super(customMemory.numberOfBanks, customMemory.numberOfBanks);
+export const toSlottedMemory = (memModel: CustomMemoryType): SlottedMemoryInfo => {
+	let slots: SlotInfo[] = memModel.map(slot => {
+		const begin = toNumber(slot.range[0]);
+		const end = toNumber(slot.range[1]);
+		const size = end - begin + 1;
+		return {
+			rom: slot.rom,
+			romOffset: slot.romOffset,
+			begin,
+			end,
+			size,
+			populated: true,
+			bankCount: slot.banked ? slot.banked.count : 1,
+			banked: slot.banked,
+			firstBank: -1,
+			sizeInPages: -1
+		};
+	});
 
-		// Set all banks
-		const nob = customMemory.numberOfBanks;
-		for (let b = 0; b < nob; b++) {
-			let bankName = customMemory.banks[b.toString()];
-			let bankType = BankType.UNUSED;	// Default
-			if (bankName != undefined)
-				bankType = (BankType as any)[bankName];
-			this.bankTypes[b] = bankType;
-			if (bankType == BankType.UNUSED) {
-				// Fill unused banks with 0xFF
-				this.fillBank(b, 0xFF);
+	// Check overlapping and fill the gaps
+	slots = slots.reduce((list, slot, i) => {
+		Utility.assert((slot.size % 1024) === 0, `Slot ${i} size not multiple of 1K`);
+		list.push(slot);
+
+		Utility.assert(slot.begin >= 0 && slot.end < 0x10000, "Slot out of 16-bit range");
+		if (i > 0) {
+			Utility.assert(slot.begin > slots[i - 1].end, `Slots ${i - 1} and ${i} are overlapping or out-of order`);
+		}
+		if (i < slots.length - 1) {
+			Utility.assert(slot.end < slots[i + 1].begin, `Slots ${i} and ${i + 1} are overlapping or out-of order`);
+			if (slot.end + 1 < slots[i + 1].begin) {
+				// Fill unpopulated slot
+				list.push({
+					begin: slot.end + 1,
+					end: slots[i + 1].begin - 1,
+					populated: false,
+					size: slots[i + 1].begin - slot.end - 1,
+					bankCount: 1,
+					sizeInPages: -1,
+					firstBank: -1
+				});
 			}
+		} else {
+			if (slot.end < 0xffff) {
+				// Fill unpopulated slot
+				list.push({
+					begin: slot.end + 1,
+					end: 0xffff,
+					populated: false,
+					size: 0x10000 - slot.end - 1,
+					sizeInPages: -1,
+					bankCount: 1,
+					firstBank: -1
+				});
+			}
+		}
+		return list;
+	}, [] as SlotInfo[]);
+
+	const slotSize = Math.min(...slots.map(slot => slot.size));
+	slots.forEach(slot => {
+		slot.sizeInPages = slot.size / slotSize;
+		slot.bankCount *= slot.sizeInPages;
+	});
+
+	// Allocated non-populated bank
+	let bankCount = 0;
+	let notPopulatedBank = -1;
+	slots.forEach(slot => {
+		if (slot.populated) {
+			slot.firstBank = bankCount;
+			bankCount += slot.bankCount;
+		} else {
+			if (notPopulatedBank < 0) {
+				notPopulatedBank = bankCount;
+				bankCount++;
+			}
+			slot.firstBank = notPopulatedBank;
+		}
+	});
+
+	return { slots, slotSize, bankCount, notPopulatedBank, bankSize: 0x10000 / slotSize };
+}
+
+export class CustomMemory extends SimulatedMemory {
+	constructor(info: SlottedMemoryInfo, private readonly ports: Z80Ports) {
+		super(info.bankSize, info.bankCount);
+
+		// Add a bank for the non-populated bank
+		if (info.notPopulatedBank >= 0) {
+			this.bankTypes[info.notPopulatedBank] = BankType.UNUSED;
+		}
+
+		info.slots.forEach(slot => {
+			const firstSlot = slot.begin / info.slotSize;
+			if (slot.rom) {
+				const offset = toNumber(slot.romOffset || 0);
+				for (let i = 0; i < slot.bankCount; i++) {
+					this.readRomToBank(slot.rom, slot.firstBank + i, info.slotSize * i + offset);
+				}
+			}
+
+			const bankControl = slot.banked && slot.banked.control;
+			if (bankControl) {
+				const matcher = this.decodePortMask(bankControl.ioPort);
+				this.ports.registerGenericOutPortFunction((port, value) => {
+					if (matcher(port)) {
+						const bank = this.decodeBankBits(value, bankControl.ioBitMap) * slot.sizeInPages;
+						for (let i = 0; i < slot.sizeInPages; i++) {
+							this.setSlot(firstSlot + i, slot.firstBank + bank + i);
+						}
+					}
+				});
+			}
+		});
+	}
+
+	private readHexFromFile(filePath: string, bankSize: number, offset: number): Uint8Array {
+		const { data }: { data: Buffer } = require("intel-hex").parse(fs.readFileSync(filePath));
+		Utility.assert(data.length >= offset + bankSize, `HEX file ${filePath} length error`);
+		return data.slice(offset, bankSize + offset);
+	}
+
+	private readRomFile(filePath: string, bankSize: number, offset: number): Uint8Array {
+		switch (path.extname(filePath).toLowerCase()) {
+		case ".hex":
+			return this.readHexFromFile(filePath, bankSize, offset);
+		case ".bin":
+		case ".rom":
+			const romBuffer = fs.readFileSync(filePath);
+			Utility.assert(romBuffer.length >= offset + bankSize, `ROM file ${filePath} length error`);
+			return new Uint8Array(romBuffer.buffer, offset, bankSize);
+		default:
+			throw new Error(`Unknown ROM extension file: ${filePath}`);
 		}
 	}
 
+	/**
+	 * Read a binary file as ROM data to a specific bank.
+	 * Supports raw format (.bin and .rom extensions) and I8HEX format (.hex extension)
+	 */
+	private readRomToBank(pathOrData: string | Uint8Array, bank: number, offset?: number) {
+		offset = offset || 0;
+		this.bankTypes[bank] = BankType.ROM;
+		let rom: Uint8Array;
+		if (typeof pathOrData === "string") {
+			rom = this.readRomFile(pathOrData, this.bankSize, offset || 0);
+		} else {
+			Utility.assert(pathOrData.length >= offset + this.bankSize, `ROM data length error`);
+			rom = new Uint8Array(pathOrData, offset, this.bankSize);
+		}
+		this.writeBank(bank, rom);
+	}
+
+	private decodeBankBits(byte: number, bitmap: number[]): number {
+		let ret = 0;
+		for (let b = 0, val = 1; b < bitmap.length; b++, val <<= 1) {
+			const mask = 1 << bitmap[b];
+			if (byte & mask) {
+				ret += val;
+			}
+		}
+		return ret;
+	}
+
+	private decodePortMask(port: HexNumber | { mask: HexNumber, match: HexNumber }): (port: number) => boolean {
+		if (typeof port === "number" || typeof port === "string") {
+			const match = toNumber(port);
+			return port => match === port;
+		} else {
+			const mask = toNumber(port.mask);
+			const match = toNumber(port.match);
+			return port => (port & mask) === match;
+		}
+	}
 }
 

--- a/src/remotes/zsimulator/custommemory.ts
+++ b/src/remotes/zsimulator/custommemory.ts
@@ -46,6 +46,6 @@ export class CustomMemory extends SimulatedMemory {
 	private readRomToBank(data: Uint8Array, bankId: number, offset: number) {
 		this.bankTypes[bankId] = BankType.ROM;
 		Utility.assert(data.length >= offset + this.bankSize, `ROM data length error`);
-		this.writeBank(bankId, data);
+		this.writeBank(bankId, data.slice(offset, this.bankSize + offset));
 	}
 }

--- a/src/remotes/zsimulator/custommemory.ts
+++ b/src/remotes/zsimulator/custommemory.ts
@@ -1,143 +1,37 @@
 import { BankType, SimulatedMemory } from './simmemory';
-import { MemoryBank, MemoryModel } from '../Paging/memorymodel';
-import { HexNumber, CustomMemoryType, ZSimCustomMemorySlot } from '../../settings';
-import { Utility } from '../../misc/utility';
 import { Z80Ports } from './z80ports';
-import * as path from 'path';
-import * as fs from 'fs';
-
-const toNumber = (hex: HexNumber): number => {
-	return Utility.parseValue(hex.toString());
-};
-
-interface SlotInfo extends Omit<ZSimCustomMemorySlot, "range"> {
-	begin: number;
-	end: number;
-	size: number;
-	sizeInPages: number;
-	populated?: boolean;
-	bankCount: number;
-	firstBank: number;
-}
-
-export interface SlottedMemoryInfo {
-	bankSize: number;
-	bankCount: number;
-	slots: SlotInfo[];
-	slotSize: number;
-	notPopulatedBank: number;
-}
-
-export const toSlottedMemory = (memModel: CustomMemoryType): SlottedMemoryInfo => {
-	let slots: SlotInfo[] = memModel.map(slot => {
-		const begin = toNumber(slot.range[0]);
-		const end = toNumber(slot.range[1]);
-		const size = end - begin + 1;
-		return {
-			rom: slot.rom,
-			romOffset: slot.romOffset,
-			begin,
-			end,
-			size,
-			populated: true,
-			bankCount: slot.banked ? slot.banked.count : 1,
-			banked: slot.banked,
-			firstBank: -1,
-			sizeInPages: -1
-		};
-	});
-
-	// Check overlapping and fill the gaps
-	slots = slots.reduce((list, slot, i) => {
-		Utility.assert((slot.size % 1024) === 0, `Slot ${i} size not multiple of 1K`);
-		list.push(slot);
-
-		Utility.assert(slot.begin >= 0 && slot.end < 0x10000, "Slot out of 16-bit range");
-		if (i > 0) {
-			Utility.assert(slot.begin > slots[i - 1].end, `Slots ${i - 1} and ${i} are overlapping or out-of order`);
-		}
-		if (i < slots.length - 1) {
-			Utility.assert(slot.end < slots[i + 1].begin, `Slots ${i} and ${i + 1} are overlapping or out-of order`);
-			if (slot.end + 1 < slots[i + 1].begin) {
-				// Fill unpopulated slot
-				list.push({
-					begin: slot.end + 1,
-					end: slots[i + 1].begin - 1,
-					populated: false,
-					size: slots[i + 1].begin - slot.end - 1,
-					bankCount: 1,
-					sizeInPages: -1,
-					firstBank: -1
-				});
-			}
-		} else {
-			if (slot.end < 0xffff) {
-				// Fill unpopulated slot
-				list.push({
-					begin: slot.end + 1,
-					end: 0xffff,
-					populated: false,
-					size: 0x10000 - slot.end - 1,
-					sizeInPages: -1,
-					bankCount: 1,
-					firstBank: -1
-				});
-			}
-		}
-		return list;
-	}, [] as SlotInfo[]);
-
-	const slotSize = Math.min(...slots.map(slot => slot.size));
-	slots.forEach(slot => {
-		slot.sizeInPages = slot.size / slotSize;
-		slot.bankCount *= slot.sizeInPages;
-	});
-
-	// Allocated non-populated bank
-	let bankCount = 0;
-	let notPopulatedBank = -1;
-	slots.forEach(slot => {
-		if (slot.populated) {
-			slot.firstBank = bankCount;
-			bankCount += slot.bankCount;
-		} else {
-			if (notPopulatedBank < 0) {
-				notPopulatedBank = bankCount;
-				bankCount++;
-			}
-			slot.firstBank = notPopulatedBank;
-		}
-	});
-
-	return { slots, slotSize, bankCount, notPopulatedBank, bankSize: 0x10000 / slotSize };
-}
+import { CustomMemorySettings } from '../../custommemorysettings';
+import { Utility } from '../../misc/utility';
 
 export class CustomMemory extends SimulatedMemory {
-	constructor(info: SlottedMemoryInfo, private readonly ports: Z80Ports) {
-		super(info.bankSize, info.bankCount);
+	constructor(info: CustomMemorySettings, private readonly ports: Z80Ports) {
+		super(0x10000 / info.uniformSlotSize, info.uniformBankCount);
 
-		// Add a bank for the non-populated bank
-		if (info.notPopulatedBank >= 0) {
-			this.bankTypes[info.notPopulatedBank] = BankType.UNUSED;
+		// Add a bank for the non-populated bank,
+		if (info.unusedBankIdx >= 0) {
+			// read as 0xFF (floating bus) and non-writable
+			this.bankTypes[info.unusedBankIdx] = BankType.UNUSED;
+			this.fillBank(info.unusedBankIdx, 0xFF);
 		}
 
 		info.slots.forEach(slot => {
-			const firstSlot = slot.begin / info.slotSize;
+			const sizeInPages = slot.size / info.uniformSlotSize;
+			const bankCount = sizeInPages * slot.bankInfo.count;
 			if (slot.rom) {
-				const offset = toNumber(slot.romOffset || 0);
-				for (let i = 0; i < slot.bankCount; i++) {
-					this.readRomToBank(slot.rom, slot.firstBank + i, info.slotSize * i + offset);
+				const offset = slot.romOffset || 0;
+				for (let i = 0; i < bankCount; i++) {
+					this.readRomToBank(slot.rom, slot.firstBankIdx + i, info.uniformSlotSize * i + offset);
 				}
 			}
 
-			const bankControl = slot.banked && slot.banked.control;
-			if (bankControl) {
-				const matcher = this.decodePortMask(bankControl.ioPort);
+			const portMaskDecoder = slot.bankInfo && slot.bankInfo.mmuHandler;
+			if (portMaskDecoder) {
 				this.ports.registerGenericOutPortFunction((port, value) => {
-					if (matcher(port)) {
-						const bank = this.decodeBankBits(value, bankControl.ioBitMap) * slot.sizeInPages;
-						for (let i = 0; i < slot.sizeInPages; i++) {
-							this.setSlot(firstSlot + i, slot.firstBank + bank + i);
+					const portValue = portMaskDecoder(port, value);
+					if (portValue >= 0) {
+						const firstBankOfGroup = portValue * sizeInPages;
+						for (let i = 0; i < sizeInPages; i++) {
+							this.setSlot(slot.firstSlotIdx + i, slot.firstBankIdx + firstBankOfGroup + i);
 						}
 					}
 				});
@@ -145,63 +39,13 @@ export class CustomMemory extends SimulatedMemory {
 		});
 	}
 
-	private readHexFromFile(filePath: string, bankSize: number, offset: number): Uint8Array {
-		const { data }: { data: Buffer } = require("intel-hex").parse(fs.readFileSync(filePath));
-		Utility.assert(data.length >= offset + bankSize, `HEX file ${filePath} length error`);
-		return data.slice(offset, bankSize + offset);
-	}
-
-	private readRomFile(filePath: string, bankSize: number, offset: number): Uint8Array {
-		switch (path.extname(filePath).toLowerCase()) {
-		case ".hex":
-			return this.readHexFromFile(filePath, bankSize, offset);
-		case ".bin":
-		case ".rom":
-			const romBuffer = fs.readFileSync(filePath);
-			Utility.assert(romBuffer.length >= offset + bankSize, `ROM file ${filePath} length error`);
-			return new Uint8Array(romBuffer.buffer, offset, bankSize);
-		default:
-			throw new Error(`Unknown ROM extension file: ${filePath}`);
-		}
-	}
-
 	/**
 	 * Read a binary file as ROM data to a specific bank.
 	 * Supports raw format (.bin and .rom extensions) and I8HEX format (.hex extension)
 	 */
-	private readRomToBank(pathOrData: string | Uint8Array, bank: number, offset?: number) {
-		offset = offset || 0;
-		this.bankTypes[bank] = BankType.ROM;
-		let rom: Uint8Array;
-		if (typeof pathOrData === "string") {
-			rom = this.readRomFile(pathOrData, this.bankSize, offset || 0);
-		} else {
-			Utility.assert(pathOrData.length >= offset + this.bankSize, `ROM data length error`);
-			rom = new Uint8Array(pathOrData, offset, this.bankSize);
-		}
-		this.writeBank(bank, rom);
-	}
-
-	private decodeBankBits(byte: number, bitmap: number[]): number {
-		let ret = 0;
-		for (let b = 0, val = 1; b < bitmap.length; b++, val <<= 1) {
-			const mask = 1 << bitmap[b];
-			if (byte & mask) {
-				ret += val;
-			}
-		}
-		return ret;
-	}
-
-	private decodePortMask(port: HexNumber | { mask: HexNumber, match: HexNumber }): (port: number) => boolean {
-		if (typeof port === "number" || typeof port === "string") {
-			const match = toNumber(port);
-			return port => match === port;
-		} else {
-			const mask = toNumber(port.mask);
-			const match = toNumber(port.match);
-			return port => (port & mask) === match;
-		}
+	private readRomToBank(data: Uint8Array, bankId: number, offset: number) {
+		this.bankTypes[bankId] = BankType.ROM;
+		Utility.assert(data.length >= offset + this.bankSize, `ROM data length error`);
+		this.writeBank(bankId, data);
 	}
 }
-

--- a/src/remotes/zsimulator/simmemory.ts
+++ b/src/remotes/zsimulator/simmemory.ts
@@ -512,8 +512,7 @@ export class SimulatedMemory implements Serializeable {
 	 * Returns the slots array, or undefined if not paged.
 	 */
 	public getSlots(): number[] | undefined {
-		//return this.slots;
-		return undefined;
+		return this.slots;
 	}
 
 

--- a/src/remotes/zsimulator/zsimremote.ts
+++ b/src/remotes/zsimulator/zsimremote.ts
@@ -356,7 +356,7 @@ export class ZSimRemote extends DzrpRemote {
 					// Custom Memory Model
 					const slottedInfo =	toCustomMemorySettings(zsim.customMemory);
 					this.memoryModel = new CustomMemoryModel(slottedInfo);
-					this.memory = new CustomMemory(slottedInfo, this.z80Cpu.ports);
+					this.memory = new CustomMemory(slottedInfo, this.ports);
 				}
 				break;
 			default:

--- a/src/remotes/zsimulator/zsimremote.ts
+++ b/src/remotes/zsimulator/zsimremote.ts
@@ -355,8 +355,8 @@ export class ZSimRemote extends DzrpRemote {
 				{
 					// Custom Memory Model
 					const slottedInfo =	toCustomMemorySettings(zsim.customMemory);
-					this.memoryModel = new CustomMemoryModel(slottedInfo);
 					this.memory = new CustomMemory(slottedInfo, this.ports);
+					this.memoryModel = new CustomMemoryModel(slottedInfo, this.memory as CustomMemory);
 				}
 				break;
 			default:

--- a/src/remotes/zsimulator/zsimremote.ts
+++ b/src/remotes/zsimulator/zsimremote.ts
@@ -22,7 +22,8 @@ import {CustomCode} from './customcode';
 import {BeeperBuffer, ZxBeeper} from './zxbeeper';
 import {GenericBreakpoint} from '../../genericwatchpoint';
 import {Z80RegistersStandardDecoder} from '../z80registersstandarddecoder';
-import {CustomMemory, toSlottedMemory} from './custommemory';
+import {CustomMemory} from './custommemory';
+import {toCustomMemorySettings} from '../../custommemorysettings';
 
 
 
@@ -353,7 +354,7 @@ export class ZSimRemote extends DzrpRemote {
 			case "CUSTOM":
 				{
 					// Custom Memory Model
-					const slottedInfo =	toSlottedMemory(zsim.customMemory);
+					const slottedInfo =	toCustomMemorySettings(zsim.customMemory);
 					this.memoryModel = new CustomMemoryModel(slottedInfo);
 					this.memory = new CustomMemory(slottedInfo, this.z80Cpu.ports);
 				}

--- a/src/remotes/zsimulator/zsimremote.ts
+++ b/src/remotes/zsimulator/zsimremote.ts
@@ -22,7 +22,7 @@ import {CustomCode} from './customcode';
 import {BeeperBuffer, ZxBeeper} from './zxbeeper';
 import {GenericBreakpoint} from '../../genericwatchpoint';
 import {Z80RegistersStandardDecoder} from '../z80registersstandarddecoder';
-import {CustomMemory} from './custommemory';
+import {CustomMemory, toSlottedMemory} from './custommemory';
 
 
 
@@ -353,8 +353,9 @@ export class ZSimRemote extends DzrpRemote {
 			case "CUSTOM":
 				{
 					// Custom Memory Model
-					this.memoryModel = new CustomMemoryModel(zsim.customMemory);
-					this.memory = new CustomMemory(zsim.customMemory);
+					const slottedInfo =	toSlottedMemory(zsim.customMemory);
+					this.memoryModel = new CustomMemoryModel(slottedInfo);
+					this.memory = new CustomMemory(slottedInfo, this.z80Cpu.ports);
 				}
 				break;
 			default:

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -163,8 +163,8 @@ export type HexNumber = number | string;
  */
 export interface CustomMemorySlot {
 	/**
-	 * The slot range (inclusive).
-	 * Slot size should not be smaller than 1K.
+	 * Array of two elements: first and last address of the slot (inclusive).
+	 * Minimum slot size and granularity is 1Kb.
 	 */
 	range: [HexNumber, HexNumber];
 
@@ -177,12 +177,12 @@ export interface CustomMemorySlot {
 	rom?: string | Uint8Array;
 
 	/**
-	 * (optional) display name of the slot
+	 * (optional) display name of the slot. If banked, it can be overridden by bank names
 	 */
 	name?: string;
 
 	/**
-	 * Offsets the ROM file/content
+	 * Optional offset of the ROM file/content
 	 */
 	romOffset?: HexNumber;
 
@@ -197,14 +197,16 @@ export interface CustomMemorySlot {
  */
 export interface CustomMemoryMmuInfo {
 	/**
-	 * The I/O port that control the banks (lower 8-bit address)
+	 * The I/O port that control the banks (full 16-bit address)
+	 * If an object, `mask` is a 16-bit mask to filter the current address (mask to 1), and `match` is the
+	 * address match of the result mask.
 	 */
 	port: HexNumber | { mask: HexNumber, match: HexNumber };
 
 	/**
-	 * List of the bits of the byte that forms the bank selector
+	 * List of the bit number (b0 to b7) of the port data value to forms the selected bank ID.
 	 */
-	bitMap: number[];
+	dataBits: number[];
 }
 
 export interface CustomMemoryBankInfo {
@@ -270,14 +272,8 @@ export interface ZSimType {
 	memoryModel: "RAM" | "ZX16K" | "ZX48K" | "ZX128K" | "ZXNEXT" | "CUSTOM",
 
 	/** A user defined memory.
-	 * "customMemory": {
-	 *	"numberOfBanks": 4,
-	 *		"banks": {
-	 *			"0": "ROM",
-	 *			"1": "RAM"
-	 *		}
-	 *	},
-	 */
+	 * Only evaluated if 'memoryModel' is set to 'CUSTOM'. Define the memory layout
+	 * as list of ranges (slots) in the 64k addressing space. */
 	customMemory: CustomMemoryType,
 
 	// The number of interrupts to calculate the average from. 0 to disable.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -149,7 +149,7 @@ export interface CustomCodeType {
 /**
  * The user can define a custom memory.
  */
-export type CustomMemoryType = Array<ZSimCustomMemorySlot>;
+export type CustomMemoryType = Array<CustomMemorySlot>;
 
 
 /**
@@ -161,7 +161,7 @@ export type HexNumber = number | string;
 /**
  * Custom layout of a `zsim` remote memory slot
  */
-export interface ZSimCustomMemorySlot {
+export interface CustomMemorySlot {
 	/**
 	 * The slot range (inclusive).
 	 * Slot size should not be smaller than 1K.
@@ -171,44 +171,57 @@ export interface ZSimCustomMemorySlot {
 	/**
 	 * Optional. If specified, set the slot as ROM.
 	 * The content is the buffer content, or the path of the ROM content.
-	 * File content (or buffer) should be in raw format (i.e. `.rom` and `.bin` extensions) or Intel HEX 8-bit format (`.hex` extensions)
+	 * File content should be in raw format (i.e. `.rom` and `.bin` extensions) or Intel HEX 8-bit format (`.hex` extensions).
+	 * Array content is flat and it should cover the whole bank span (if banked).
 	 */
 	rom?: string | Uint8Array;
 
 	/**
-	 * Offset the ROM file
+	 * (optional) display name of the slot
+	 */
+	name?: string;
+
+	/**
+	 * Offsets the ROM file/content
 	 */
 	romOffset?: HexNumber;
 
 	/**
 	 * If set, enables banking on such slot.
 	 */
-	banked?: {
-		/**
-		 * Count of banks that can be mapped on such slot
-		 */
-		count: number;
+	banked?: CustomMemoryBankInfo;
+}
 
-		/**
-		 * Declare how banks are switched
-		 */
-		control?: {
-			/**
-			 * The I/O port that control the banks (lower 8-bit address)
-			 */
-			ioPort: HexNumber | { mask: HexNumber, match: HexNumber };
+/**
+ * Description of Memory management unit (bank switcher) accessed via single I/O port
+ */
+export interface CustomMemoryMmuInfo {
+	/**
+	 * The I/O port that control the banks (lower 8-bit address)
+	 */
+	port: HexNumber | { mask: HexNumber, match: HexNumber };
 
-			/**
-			 * List of the bits of the byte that forms the bank selector
-			 */
-			ioBitMap: number[];
+	/**
+	 * List of the bits of the byte that forms the bank selector
+	 */
+	bitMap: number[];
+}
 
-			/**
-			 * True if the port can be read back
-			 */
-			readwrite?: boolean;
-		}
-	}
+export interface CustomMemoryBankInfo {
+	/**
+	 * Count of banks that can be mapped on such slot
+	 */
+	count: number;
+
+	/**
+	 * (optional) display names of the banks
+	 */
+	names?: string[];
+
+	/**
+	 * Optional memory management unit (bank switcher) accessed via single I/O port
+	 */
+	ioMmu?: CustomMemoryMmuInfo;
 }
 
 

--- a/tests/custommemory.tests.ts
+++ b/tests/custommemory.tests.ts
@@ -1,0 +1,62 @@
+
+import * as assert from 'assert';
+import { CustomMemoryModel } from '../src/remotes/Paging/memorymodel';
+import {CustomMemory, toSlottedMemory} from '../src/remotes/zsimulator/customMemory';
+import { Z80Ports } from '../src/remotes/zsimulator/z80ports';
+
+// ROM that contains 0, 1, ... 0xff repeated to fill the target size
+const buildTestRom = (size: number) => {
+	const buffer = new Uint8Array(size);
+	for (let i = 0; i < size; i++) {
+		buffer[i] = i % 0x100;
+	}
+	return buffer;
+};
+
+suite('CustomMemory', () => {
+	test('ROM load', () => {
+		// test.rom is a 8K ROM
+		const mem = new CustomMemory(toSlottedMemory([
+			{
+				range: [0, 0x3FFF],
+				rom: buildTestRom(16 * 1024)
+			},
+			{
+				range: [0x4000, 0xBFFF]
+			}
+		]), new Z80Ports(0xff));
+
+		assert.equal(0x00, mem.read8(0x0000));
+		assert.equal(0x01, mem.read8(0x0001));
+		assert.equal(0x02, mem.read8(0x0002));
+		assert.equal(0xFF, mem.read8(0x3FFF));
+
+		assert.equal(0x00, mem.read8(0x4000));
+		assert.equal(0x00, mem.read8(0x4001));
+
+		assert.equal(0x00, mem.read8(0x7FFF));
+		assert.equal(0x00, mem.read8(0x8000));
+		assert.equal(0x00, mem.read8(0x8001));
+		assert.equal(0x00, mem.read8(0xBFFF));
+
+		assert.equal(0xff, mem.read8(0xC000));
+		assert.equal(0xff, mem.read8(0xFFFF));
+	});
+
+	test('Memory model', () => {
+		const memoryModel = new CustomMemoryModel(toSlottedMemory([
+			{
+				range: [0, 0x3FFF],
+				rom: buildTestRom(16 * 1024)
+			},
+			{
+				range: [0x4000, 0xBFFF]
+			}
+		]));
+		const banks = memoryModel.getMemoryBanks(undefined);
+		assert.deepEqual({ name: "ROM", start: 0, end: 0x3FFF }, banks[0]);
+		assert.deepEqual({ name: "BANK1", start: 0x4000, end: 0x7FFF }, banks[1]);
+		assert.deepEqual({ name: "BANK2", start: 0x8000, end: 0xBFFF }, banks[2]);
+		assert.deepEqual({ name: "N/A", start: 0xC000, end: 0xFFFF }, banks[3]);
+	});
+});

--- a/tests/custommemory.tests.ts
+++ b/tests/custommemory.tests.ts
@@ -1,7 +1,8 @@
 
 import * as assert from 'assert';
 import { CustomMemoryModel } from '../src/remotes/Paging/memorymodel';
-import {CustomMemory, toSlottedMemory} from '../src/remotes/zsimulator/customMemory';
+import { CustomMemory } from '../src/remotes/zsimulator/customMemory';
+import { toCustomMemorySettings } from '../src/custommemorysettings';
 import { Z80Ports } from '../src/remotes/zsimulator/z80ports';
 
 // ROM that contains 0, 1, ... 0xff repeated to fill the target size
@@ -16,7 +17,7 @@ const buildTestRom = (size: number) => {
 suite('CustomMemory', () => {
 	test('ROM load', () => {
 		// test.rom is a 8K ROM
-		const mem = new CustomMemory(toSlottedMemory([
+		const mem = new CustomMemory(toCustomMemorySettings([
 			{
 				range: [0, 0x3FFF],
 				rom: buildTestRom(16 * 1024)
@@ -43,8 +44,8 @@ suite('CustomMemory', () => {
 		assert.equal(0xff, mem.read8(0xFFFF));
 	});
 
-	test('Memory model', () => {
-		const memoryModel = new CustomMemoryModel(toSlottedMemory([
+	test('Memory model, not banked', () => {
+		const memoryModel = new CustomMemoryModel(toCustomMemorySettings([
 			{
 				range: [0, 0x3FFF],
 				rom: buildTestRom(16 * 1024)
@@ -54,9 +55,85 @@ suite('CustomMemory', () => {
 			}
 		]));
 		const banks = memoryModel.getMemoryBanks(undefined);
-		assert.deepEqual({ name: "ROM", start: 0, end: 0x3FFF }, banks[0]);
-		assert.deepEqual({ name: "BANK1", start: 0x4000, end: 0x7FFF }, banks[1]);
-		assert.deepEqual({ name: "BANK2", start: 0x8000, end: 0xBFFF }, banks[2]);
-		assert.deepEqual({ name: "N/A", start: 0xC000, end: 0xFFFF }, banks[3]);
+		assert.deepEqual([
+			{ name: "ROM", start: 0, end: 0x3FFF },
+			{ name: "RAM", start: 0x4000, end: 0xBFFF },
+			{ name: "N/A", start: 0xC000, end: 0xFFFF }], banks);
+	});
+
+	test('Memory model, simple banked', () => {
+		const customSettings = toCustomMemorySettings([
+			{
+				range: [0, 0x3FFF],
+				rom: buildTestRom(16 * 1024)
+			},
+			{
+				range: [0x4000, 0xBFFF],
+				banked: {
+					count: 2
+				}
+			}
+		]);
+		assert.equal(customSettings.uniformSlotSize, 0x4000);
+		assert.equal(customSettings.uniformBankCount, 6); // 1 ROM, 4 RAM (2 banks of 2 slots), 1 N/A
+		assert.equal(customSettings.slots[0].firstBankIdx, 0);
+		assert.equal(customSettings.slots[1].firstBankIdx, 1);
+		assert.equal(customSettings.slots[2].firstBankIdx, 5);
+		assert.equal(customSettings.unusedBankIdx, 5);
+
+		const memoryModel = new CustomMemoryModel(customSettings);
+
+		let banks = memoryModel.getMemoryBanks(undefined);
+		assert.deepEqual([
+			{ name: "ROM", start: 0, end: 0x3FFF },
+			{ name: "RAM", start: 0x4000, end: 0xBFFF },
+			{ name: "N/A", start: 0xC000, end: 0xFFFF }], banks);
+
+		banks = memoryModel.getMemoryBanks([0, 1, 2, 5]);
+		assert.deepEqual([
+			{ name: "ROM", start: 0, end: 0x3FFF },
+			{ name: "RAM0", start: 0x4000, end: 0xBFFF },
+			{ name: "N/A", start: 0xC000, end: 0xFFFF }], banks);
+
+		banks = memoryModel.getMemoryBanks([0, 3, 4, 5]);
+		assert.deepEqual([
+			{ name: "ROM", start: 0, end: 0x3FFF },
+			{ name: "RAM1", start: 0x4000, end: 0xBFFF },
+			{ name: "N/A", start: 0xC000, end: 0xFFFF }], banks);
+	});
+
+	test('Memory model, banked w/names', () => {
+		const memoryModel = new CustomMemoryModel(toCustomMemorySettings([
+			{
+				range: [0, 0x3FFF],
+				rom: buildTestRom(16 * 1024),
+				name: "X"
+			},
+			{
+				range: [0x4000, 0xBFFF],
+				banked: {
+					count: 2,
+					names: ["R1", "R2"]
+				}
+			}
+		]));
+
+		let banks = memoryModel.getMemoryBanks(undefined);
+		assert.deepEqual([
+			{ name: "X", start: 0, end: 0x3FFF },
+			{ name: "RAM", start: 0x4000, end: 0xBFFF },
+			{ name: "N/A", start: 0xC000, end: 0xFFFF }], banks);
+
+		banks = memoryModel.getMemoryBanks([0, 1, 2, 5]);
+		assert.deepEqual([
+			{ name: "X", start: 0, end: 0x3FFF },
+			{ name: "R1", start: 0x4000, end: 0xBFFF },
+			{ name: "N/A", start: 0xC000, end: 0xFFFF }], banks);
+
+		banks = memoryModel.getMemoryBanks([0, 3, 4, 5]);
+		assert.deepEqual([
+			{ name: "X", start: 0, end: 0x3FFF },
+			{ name: "R2", start: 0x4000, end: 0xBFFF },
+			{ name: "N/A", start: 0xC000, end: 0xFFFF }], banks);
 	});
 });


### PR DESCRIPTION
Here a viable implementation of "non-uniform" bank switching support via configuration.
The implementation is still completely based on `SimulatedMemory`, but it offer the possibility of having non-uniform slot sizes. In real vintage hardware, in case the addressing is not covering the full 64kb space (e.g. old arcade multi-Z80 boards or custom industrial boards), different circuitry could be used to decode the address and enable different hardware.

So with this PR is possible to declare the memory layout using ranges, e.g.: 
```js
{
    // ...
    "customMemory": [
      // 0-3FFF: 16kB ROM
      { "range": [0, "3FFFh"], "rom": "rom.hex", "name": "ROM" },
      // 4000-6000: RAM: smaller slot of 8kb
      { "range": ["4000h", "5FFFh"], "name": "common" },
      // 6000-8000: Not populated
      // 8000-FFFF: paged, 16 banks of 32Kb
      { "range": ["8000h", "FFFFh"], "banked": {
          "count": 16,
          // I/O port 80 selects the active page, with the lower 4-bits
          "ioMmu": {
              "port": { "mask": "FFh", "match": "80h" },
              "dataBits": [0, 1, 2, 3]
          }
      } }
    ]
}
```

So in this case the memory layout is 16k/8k/8k/32k:

![image](https://user-images.githubusercontent.com/747421/160923072-1f204666-d2bb-4c7a-903c-04128674a530.png)

In addition, the PR contains the implementation of automatic bank switching logic listening to I/O `out` operation. 

A new class `CustomMemory` does all the logic. In order to share the same settings with the paired `CustomMemoryModel`, a `CustomMemorySettings` class contains all the decoded information from the public settings.

In addition, I've added the support to Intel .hex file (for ROM content). I've found a handy npm dependency for that, but rather poorly tested. By the way, the file format is simple enough for the external code to be rewritten inside this project (if you don't like the proliferation of 3rd party dependencies).

I was mentioning the declarative bank switch support in maziac/DeZog#74, and I understand your concern about the real necessity of declarative syntax: in the 99% of cases, custom code will be required to complete the simulation.

However, I would like to see "natively" supported the most common patterns when declaring the hardware of a custom board. Having a sort of guided "auto-complete" data object is always preferable to write custom code: code is always prone to copy/paste error propagation (unless you offer a strong API that requires simple configuration objects), and less controllable in terms of correctness of operation / overall performances.

I'm working on a project around this custom extension board: https://github.com/lmartorella/olivetti-plu, and I found DeZog incredibly flexible as a reverse engineering tool / prototyping tool.
I see a lot of potential in this project, and it is not so unlikely that it can become the universal IDE for all the 70s/80s/90s consoles and computers based on the Z80 CPU (and their variant too... now thinking to 8080, to CP/M, etc..), exactly as VS Code is growing fast to cover all languages and environments.

Thanks! L

*NOTE*: Other MMU implementation not based on I/O are obviously possible (e.g. via memory write, like in the ZX Interface 1 and in Sega Master System 1M cartridges), so this is only to cover the most common way to do bank switching. However it is quite easy to extend the configuration to support all the possible cases.
