### PR TITLE
fix freeze cesarux on stop debugging

### DIFF
--- a/src/remotes/zesarux/zesaruxsocket.ts
+++ b/src/remotes/zesarux/zesaruxsocket.ts
@@ -716,6 +716,7 @@ export class ZesaruxSocket extends Socket {
 				await this.sendAwait('extended-stack enabled no', false);	// NOSONAR
 				await this.sendAwait('clear-membreakpoints', false);
 				await this.sendAwait('disable-breakpoints', false);
+				await this.sendAwait('exit-cpu-step', false);
 				await this.sendAwait('quit', false);
 				// Close connection (ZEsarUX also closes the connection)
 				//zSocket.end(); // "end()" takes too long > 1 s


### PR DESCRIPTION
I found and fixed an issue when debugging with Zesarux

On stopping debugging, Zesarux would freeze in a step-cpu state and require a reboot. 
By stopping the cpu-step mode it can be reused.