### PR TITLE
Correctly manages 24 bits addresses in z88dk mapfile

### DIFF
--- a/src/labels/z88dklabelparserv2.ts
+++ b/src/labels/z88dklabelparserv2.ts
@@ -359,7 +359,16 @@ export class Z88dkLabelParserV2 extends LabelParserBase {
 			const match = this.mapFileRegEx.exec(line);
 			if (match) {
 				const label = match[1];
-				const addr64k = parseInt(match[2], 16);
+				const address = match[2];
+				let addr64k: number;
+				if (address.length > 4) {  // 24 bits address
+					const z88dkAddr = parseInt(address, 16);
+					const bank = z88dkAddr >> 16;
+					const addr16 = z88dkAddr & 0xFFFF;
+					addr64k = addr16 + ((bank + 1) << 16);
+				} else {
+					addr64k = parseInt(address, 16);
+				}
 				this.z88dkMappings.set(label, addr64k);
 			}
 		}


### PR DESCRIPTION
Background:
z88dk encodes banked addresses in map files with 4 digits for 16 bits and 6 digits for 24 bits. DeZog expects long addresses to be coded as addr16 + ((bank+1) << 16). 

Changes:
Explicitly detects 6-digit addresses in the map file.
Extracts the bank and 16-bit address, then encodes them in DeZog’s format.

Result:
Banked code and data symbols from z88dk map files are now mapped to the correct addresses in DeZog.

Fixes:
Resolves bug #167