### PR TITLE
Fixed bug where pressing 'stop' would sometimes take 5 seconds to disconnect.

### DIFF
--- a/src/remotes/mame/mamegdbremote.ts
+++ b/src/remotes/mame/mamegdbremote.ts
@@ -167,6 +167,12 @@ export class MameGdbRemote extends DzrpQueuedRemote {
 		// NOTE: Remove once MAME issue 9578 (https://github.com/mamedev/mame/issues/9578) 	is clarified:
 		this.cmdRespTimeoutTime = 0;	// No response expected for kill command.
 
+		// Cancel any in-flight timeouts and clear the queue. We want the 'k' command to be sent
+		// immediately. Otherwise there is a delay of 5 seconds before the 'k' command is actually
+		// sent, causing the debug UI bar to remain visible until the command is sent.
+		this.stopCmdRespTimeout();
+		this.messageQueue.length = 0;
+
 		try {
 			await this.sendPacketData('k');	// REMOVE with kill command
 		}


### PR DESCRIPTION
Hello!

I've been adding a gdb stub to the [Gearsystem Master System](https://github.com/drhelius/Gearsystem) emulator and I was using DeZog to test it (using the mame remote). Seems great so far! I found that sometimes hitting "stop" in VS Code would take five seconds to actually disconnect and the VS Code debug UI bar would remain visible for that time. I was tearing my hair out thinking it was something wrong with my non-blocking network code but it turns out it was a small bug in DeZog.

Sometimes when you hit stop, there is already a command in the queue (usually the get registers command). Because we call `removeAllListeners` and basically close everything down, the response for that command is never processed, so 'k' isn't sent until the timeout callback is triggered.

I figured that if you're disconnecting the debugger, whatever remaining commands are in the queue don't matter, so we can just clear the queue and send 'k' immediately.