### PR TITLE
zxnext: allow a socket connection beside the serial one

### DIFF
--- a/documentation/Usage.md
+++ b/documentation/Usage.md
@@ -1325,7 +1325,7 @@ E.g.
 
 #### Socket Connection
 
-Instead of the serial cable the ZX Next can be reached through a socket, e.g. via its ESP8266 WiFi module. Use "hostname" instead of "serial":
+Instead of the serial cable the ZX Next can be reached through a socket, e.g. via its ESP8266 WiFi module. The transport is chosen by "serial": if it is present the serial connection is used, if not the socket connection is used. I.e. omit "serial" and give "hostname":
 ~~~json
     "remoteType": "zxnext",
     "zxnext": {
@@ -1333,9 +1333,7 @@ Instead of the serial cable the ZX Next can be reached through a socket, e.g. vi
     }
 ~~~
 
-The port defaults to 11000 and can be changed with "port". Use either "serial" or "hostname", not both. The "timeout" is used for both.
-
-Note that "hostname" has no default, because its presence is what selects a socket rather than a serial device. It therefore has to be given even for a local connection: use "localhost" when the ZX Next side is on the same PC as DeZog, which is the case if the stub is running inside an emulator that exposes the WiFi module's port on the host.
+"hostname" defaults to "localhost" and "port" to 11000, so both can be omitted if the ZX Next side is on the same PC as DeZog, which is the case if the stub is running inside an emulator that exposes the WiFi module's port on the host. "hostname" and "port" are not used together with "serial". The "timeout" is used for both transports.
 
 This needs a program on the ZX Next that serves DZRP through the WiFi module. [dezogif] itself is serial only; [dezogif_ng] is a fork of it that adds a WiFi build beside the serial one, and that is what the socket connection was developed against.
 

--- a/documentation/Usage.md
+++ b/documentation/Usage.md
@@ -1322,6 +1322,20 @@ E.g.
     }
 ~~~
 
+#### Socket Connection
+
+Instead of the serial cable the ZX Next can be reached through a socket, e.g. via its ESP8266 WiFi module. Use "hostname" instead of "serial":
+~~~json
+    "remoteType": "zxnext",
+    "zxnext": {
+        "hostname": "192.168.1.42"
+    }
+~~~
+
+The port defaults to 11000 and can be changed with "port". Use either "serial" or "hostname", not both. The "timeout" is used for both.
+
+Everything above the transport is the same, i.e. the same 'dezogif' program runs on the ZX Next. There is one difference: through a socket DeZog does not refuse the pause command, see [Pausing the Debugged Program](#pausing-the-debugged-program).
+
 #### Setup
 
 Prerequisites:
@@ -1363,6 +1377,9 @@ Note: If one of the 2 joystick ports is used to connect the UART it is still pos
 While the debugged program is running there is no communication between DeZog and the ZX Next.
 I.e. it is also not possible to pause the program through the serial cable.
 For pausing your program you need to press the yellow M1 button at the left side of your ZX Next.
+
+The reason is the serial cable: when the program is continued the joy ports are given back to it, which re-points the UART's receive line away from the joy port pin. So the ZX Next cannot receive anything while the program runs.
+This does not apply to a [socket connection](#socket-connection), where the UART stays connected and a byte from DeZog can arrive at any time. DeZog therefore does not refuse the pause command there. Whether the pause takes effect depends on the program on the ZX Next: it has to notice the byte while the debugged program is running.
 
 
 #### HW

--- a/documentation/Usage.md
+++ b/documentation/Usage.md
@@ -33,6 +33,7 @@ If you would like to contribute, e.g. by adding a new assembler or adding other 
 [z80-custom-memory-model-advanced]: https://github.com/maziac/z80-custom-memory-model-advanced
 [z88dk-zcc-sample-project]: https://github.com/maziac/z88dk-zcc-sample-project
 [dezogif]: https://github.com/maziac/dezogif
+[dezogif_ng]: https://github.com/jorgegv/dezogif_ng
 [DZRP]: https://github.com/maziac/DeZog/blob/master/design/DeZogProtocol.md
 [zx81-zsim]: https://github.com/maziac/DeZog/blob/master/documentation/zx81/zx81-zsim.md
 
@@ -1334,7 +1335,9 @@ Instead of the serial cable the ZX Next can be reached through a socket, e.g. vi
 
 The port defaults to 11000 and can be changed with "port". Use either "serial" or "hostname", not both. The "timeout" is used for both.
 
-Everything above the transport is the same, i.e. the same 'dezogif' program runs on the ZX Next. There is one difference: through a socket DeZog does not refuse the pause command, see [Pausing the Debugged Program](#pausing-the-debugged-program).
+This needs a program on the ZX Next that serves DZRP through the WiFi module. [dezogif] itself is serial only; [dezogif_ng] is a fork of it that adds a WiFi build beside the serial one, and that is what the socket connection was developed against.
+
+Everything above the transport is the same, i.e. the same DZRP commands and the same breakpoint handling. There is one difference: through a socket DeZog does not refuse the pause command, see [Pausing the Debugged Program](#pausing-the-debugged-program).
 
 #### Setup
 

--- a/documentation/Usage.md
+++ b/documentation/Usage.md
@@ -1335,6 +1335,8 @@ Instead of the serial cable the ZX Next can be reached through a socket, e.g. vi
 
 The port defaults to 11000 and can be changed with "port". Use either "serial" or "hostname", not both. The "timeout" is used for both.
 
+Note that "hostname" has no default, because its presence is what selects a socket rather than a serial device. It therefore has to be given even for a local connection: use "localhost" when the ZX Next side is on the same PC as DeZog, which is the case if the stub is running inside an emulator that exposes the WiFi module's port on the host.
+
 This needs a program on the ZX Next that serves DZRP through the WiFi module. [dezogif] itself is serial only; [dezogif_ng] is a fork of it that adds a WiFi build beside the serial one, and that is what the socket connection was developed against.
 
 Everything above the transport is the same, i.e. the same DZRP commands and the same breakpoint handling. There is one difference: through a socket DeZog does not refuse the pause command, see [Pausing the Debugged Program](#pausing-the-debugged-program).

--- a/package.json
+++ b/package.json
@@ -967,16 +967,16 @@
 								"properties": {
 									"serial": {
 										"type": "string",
-										"description": "The name of the serial port interface, on macOS e.g. \"/dev/tty.usbserial-AQ\", on Windows e.g. \"COM8\". Use either 'serial' or 'hostname'.",
+										"description": "The name of the serial port interface, on macOS e.g. \"/dev/tty.usbserial-AQ\", on Windows e.g. \"COM8\". Its presence selects the serial connection, otherwise a socket connection is used.",
 										"default": ""
 									},
 									"hostname": {
 										"type": "string",
-										"description": "The hostname/IP address of the ZX Next if it is connected via a socket, e.g. through the ESP8266 WiFi module. Use either 'serial' or 'hostname'."
+										"description": "The hostname/IP address of the ZX Next if it is connected via a socket, e.g. through the ESP8266 WiFi module. Defaults to 'localhost'. Not used together with 'serial'."
 									},
 									"port": {
 										"type": "number",
-										"description": "The port of the ZX Next socket. Defaults to 11000. Only used together with 'hostname'."
+										"description": "The port of the ZX Next socket. Defaults to 11000. Not used together with 'serial'."
 									},
 									"timeout": {
 										"type": "number",

--- a/package.json
+++ b/package.json
@@ -967,8 +967,16 @@
 								"properties": {
 									"serial": {
 										"type": "string",
-										"description": "The name of the serial port interface, on macOS e.g. \"/dev/tty.usbserial-AQ\", on Windows e.g. \"COM8\"",
+										"description": "The name of the serial port interface, on macOS e.g. \"/dev/tty.usbserial-AQ\", on Windows e.g. \"COM8\". Use either 'serial' or 'hostname'.",
 										"default": ""
+									},
+									"hostname": {
+										"type": "string",
+										"description": "The hostname/IP address of the ZX Next if it is connected via a socket, e.g. through the ESP8266 WiFi module. Use either 'serial' or 'hostname'."
+									},
+									"port": {
+										"type": "number",
+										"description": "The port of the ZX Next socket. Defaults to 11000. Only used together with 'hostname'."
 									},
 									"timeout": {
 										"type": "number",

--- a/src/remotes/dzrpbuffer/zxnextserialremote.ts
+++ b/src/remotes/dzrpbuffer/zxnextserialremote.ts
@@ -59,6 +59,10 @@ export class ZxNextSerialRemote extends DzrpBufferRemote {
 	// Value to catch the MESSAGE_START_BYTE if received data was 1 byte only.
 	protected msgStartByteFound: boolean;
 
+	// True if the transport prefixes each message with the MESSAGE_START_BYTE.
+	// Only the serial connection does, see 'dataReceived'.
+	protected usesMessageStartByte = true;
+
 
 	// The time the last CMD_CONTINUE was sent. Is used to suppress the "No response received message" from the remote if a request is sent from vscode right after a CMD_CONTINUE.
 	protected lastCmdContinueTime = 0;	// ms
@@ -229,7 +233,7 @@ export class ZxNextSerialRemote extends DzrpBufferRemote {
 	protected dataReceived(data: Buffer) {
 		let nData = data;
 
-		if (this.receivedData.length == 0 && !this.msgStartByteFound) {
+		if (this.usesMessageStartByte && this.receivedData.length == 0 && !this.msgStartByteFound) {
 			// Swallow everything (zeroes) up to the first 0xA5 found
 			const len = data.length;
 			let i;

--- a/src/remotes/dzrpbuffer/zxnextsocketremote.ts
+++ b/src/remotes/dzrpbuffer/zxnextsocketremote.ts
@@ -12,9 +12,15 @@ import {ZxNextSerialRemote} from './zxnextserialremote';
  * interface, e.g. through the ZX Next's ESP8266 WiFi module.
  *
  * Everything above the transport is identical to the serial connection:
- * the same 'dezogif' program runs on the ZX Next and the same DZRP
- * breakpoint handling (CMD_SET_BREAKPOINTS/CMD_RESTORE_MEM) is used.
- * Therefore only the transport specific methods are overridden here.
+ * the same DZRP commands and the same breakpoint handling
+ * (CMD_SET_BREAKPOINTS/CMD_RESTORE_MEM) are used. Therefore only the
+ * transport specific methods are overridden here.
+ *
+ * This needs a program on the ZX Next that serves DZRP through the WiFi
+ * module. 'dezogif' (https://github.com/maziac/dezogif) is serial only;
+ * 'dezogif_ng' (https://github.com/jorgegv/dezogif_ng) is a fork of it
+ * that adds a WiFi build beside the serial one, and is what this was
+ * developed against.
  *
  * Two differences to the serial connection, both a consequence of the
  * transport:

--- a/src/remotes/dzrpbuffer/zxnextsocketremote.ts
+++ b/src/remotes/dzrpbuffer/zxnextsocketremote.ts
@@ -1,0 +1,169 @@
+import {LogTransport} from '../../log';
+import {Socket} from 'net';
+import {Settings} from '../../settings/settings';
+import {ErrorWrapper} from '../../misc/errorwrapper';
+import {CONNECTION_TIMEOUT} from './dzrpbufferremote';
+import {DZRP} from '../dzrp/dzrpremote';
+import {ZxNextSerialRemote} from './zxnextserialremote';
+
+
+/**
+ * A ZX Next remote that is connected via a socket instead of the serial
+ * interface, e.g. through the ZX Next's ESP8266 WiFi module.
+ *
+ * Everything above the transport is identical to the serial connection:
+ * the same 'dezogif' program runs on the ZX Next and the same DZRP
+ * breakpoint handling (CMD_SET_BREAKPOINTS/CMD_RESTORE_MEM) is used.
+ * Therefore only the transport specific methods are overridden here.
+ *
+ * Two differences to the serial connection, both a consequence of the
+ * transport:
+ * - No MESSAGE_START_BYTE (0xA5) is used. It exists because the ZX Next
+ *   emits zeroes through the serial cable if the joy port is not
+ *   configured. A socket does not have that problem.
+ * - CMD_PAUSE is not refused. Over the serial cable the joy ports are
+ *   given back to the debugged program when it is continued, which
+ *   re-points the UART's RX line away from the joy port pin, so the
+ *   ZX Next cannot receive anything while the program runs. Through a
+ *   socket the UART stays connected and a byte can arrive at any time.
+ *   Whether the pause takes effect is up to the program on the ZX Next,
+ *   which has to notice the byte while the debugged program runs.
+ */
+export class ZxNextSocketRemote extends ZxNextSerialRemote {
+
+	// The socket connection.
+	public socket: Socket;
+
+
+	/// Constructor.
+	constructor() {
+		super();
+		// The socket transport does not use the MESSAGE_START_BYTE.
+		this.usesMessageStartByte = false;
+	}
+
+
+	/// Override.
+	/// Initializes the machine.
+	/// When ready it emits this.emit('initialized') or this.emit('error', Error(...));
+	/// The successful emit takes place in 'onConnect' which should be called
+	/// by 'doInitialization' after a successful connect.
+	public async doInitialization(): Promise<void> {
+		// Init socket
+		this.socket = new Socket();
+		this.socket.unref();
+
+		// Set timeouts
+		this.cmdRespTimeoutTime = Settings.launch.zxnext.timeout * 1000;
+		this.chunkTimeout = this.cmdRespTimeoutTime;
+
+		// React on-open
+		this.socket.on('connect', () => {
+			(async () => {
+				LogTransport.log('ZxNextSocketRemote: Connected to ZX Next!');
+
+				this.receivedData = Buffer.alloc(0);
+				this.expectedLength = 4;	// for length
+				this.receivingHeader = true;
+				this.stopChunkTimeout();
+
+				this.longBreakedAddress = undefined;
+				this.breakpointIdLastIndex = 0;
+				await this.onConnect();
+			})();
+		});
+
+		// Handle disconnect
+		this.socket.on('close', hadError => {
+			LogTransport.log('ZxNextSocketRemote: closed connection: ' + hadError);
+			// Error
+			const err = new Error('ZX Next terminated the connection!');
+			try {
+				this.emit('error', err);
+			}
+			catch {};
+		});
+
+		// Handle errors
+		this.socket.on('error', err => {
+			ErrorWrapper.wrap(err);
+			LogTransport.log('ZxNextSocketRemote: Error: ' + err);
+			// Error
+			try {
+				this.emit('error', err);
+			}
+			catch {};
+		});
+
+		// Receive data
+		this.socket.on('data', data => {
+			this.dataReceived(data);
+		});
+
+		// Start socket connection
+		this.socket.setTimeout(CONNECTION_TIMEOUT);
+		const port = Settings.launch.zxnext.port;
+		const hostname = Settings.launch.zxnext.hostname;
+		this.socket.connect(port, hostname);
+	}
+
+
+	/**
+	 * This will disconnect the socket.
+	 */
+	public async disconnect(): Promise<void> {
+		if (!this.socket)
+			return;
+
+		// Check if socket is already open.
+		if (this.socket.readyState === 'open') {
+			// Disconnect: Removes listeners and sends a CLOSE command.
+			await super.disconnect();
+		}
+
+		return new Promise<void>(resolve => {
+			this.socket?.removeAllListeners();
+			// Timeout is required because socket.end() does not call the
+			// callback if it is already closed and the state cannot
+			// reliable be determined.
+			const timeout = setTimeout(() => {
+				if (resolve) {
+					resolve();
+				}
+			}, 1000);	// 1 sec
+			this.socket?.end(() => {
+				if (resolve) {
+					resolve();
+					clearTimeout(timeout);
+				}
+			});
+			this.socket = undefined as any;
+		});
+	}
+
+
+	/**
+	 * Writes the buffer to the socket port.
+	 */
+	protected async sendBuffer(buffer: Buffer): Promise<void> {
+		// Send buffer
+		return new Promise<void>(resolve => {
+			// Send data
+			const txt = this.dzrpCmdBufferToString(buffer);
+			LogTransport.log('>>> ZxNextSocketRemote: Sending ' + txt);
+			this.socket.write(buffer, () => {
+				resolve();
+			});
+		});
+	}
+
+
+	/**
+	 * Override of ZxNextSerialRemote, which refuses to pause because the
+	 * serial cable cannot carry anything while the debugged program runs.
+	 * Through a socket the byte does arrive, so the command is sent.
+	 */
+	protected async sendDzrpCmdPause(): Promise<void> {
+		await this.sendDzrpCmd(DZRP.CMD_PAUSE);
+	}
+}

--- a/src/remotes/remotefactory.ts
+++ b/src/remotes/remotefactory.ts
@@ -4,6 +4,7 @@ import {CSpectRemote} from './dzrpbuffer/cspectremote';
 import {Utility} from '../misc/utility';
 import {ZesaruxRemote} from './zesarux/zesaruxremote';
 import {ZxNextSerialRemote} from './dzrpbuffer/zxnextserialremote';
+import {ZxNextSocketRemote} from './dzrpbuffer/zxnextsocketremote';
 import {MameGdbRemote} from './mame/mamegdbremote';
 import {Settings} from '../settings/settings';
 
@@ -25,8 +26,11 @@ export class RemoteFactory {
 			case 'cspect':	// CSpect socket
 				RemoteFactory.setGlobalRemote(new CSpectRemote());
 				break;
-			case 'zxnext':	// The ZX Next USB/serial connection
-				RemoteFactory.setGlobalRemote(new ZxNextSerialRemote());
+			case 'zxnext':	// The ZX Next USB/serial or socket connection
+				if (Settings.launch.zxnext.hostname !== undefined)
+					RemoteFactory.setGlobalRemote(new ZxNextSocketRemote());
+				else
+					RemoteFactory.setGlobalRemote(new ZxNextSerialRemote());
 				break;
 			case 'zsim':	// Simulator
 				RemoteFactory.setGlobalRemote(new ZSimRemote(Settings.launch));

--- a/src/remotes/remotefactory.ts
+++ b/src/remotes/remotefactory.ts
@@ -27,10 +27,11 @@ export class RemoteFactory {
 				RemoteFactory.setGlobalRemote(new CSpectRemote());
 				break;
 			case 'zxnext':	// The ZX Next USB/serial or socket connection
-				if (Settings.launch.zxnext.hostname !== undefined)
-					RemoteFactory.setGlobalRemote(new ZxNextSocketRemote());
-				else
+				// 'serial' selects the serial connection, otherwise a socket is used.
+				if (Settings.launch.zxnext.serial !== undefined)
 					RemoteFactory.setGlobalRemote(new ZxNextSerialRemote());
+				else
+					RemoteFactory.setGlobalRemote(new ZxNextSocketRemote());
 				break;
 			case 'zsim':	// Simulator
 				RemoteFactory.setGlobalRemote(new ZSimRemote(Settings.launch));

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -155,14 +155,15 @@ export interface MameType {
 
 // Definitions for ZX Next remote type.
 export interface ZxNextSerialType {
-	// The serial usb device. Use either 'serial' or 'hostname'.
+	// The serial usb device. Its presence selects the serial connection,
+	// otherwise a socket connection is used.
 	serial: string;	// E.g. "/dev/cu.usbserial-AQ007PCD" on macOS
 
 	// The hostname/IP address of the ZX Next, if connected via socket
-	// (e.g. the ESP8266 WiFi module). Use either 'serial' or 'hostname'.
+	// (e.g. the ESP8266 WiFi module). Not used together with 'serial'.
 	hostname: string;
 
-	// The port of the ZX Next socket.
+	// The port of the ZX Next socket. Not used together with 'serial'.
 	port: number;
 
 	/// The timeout in seconds.
@@ -878,15 +879,20 @@ export class Settings {
 		// zxnext
 		if (!launchCfg.zxnext) {
 			launchCfg.zxnext = {} as ZxNextSerialType;
-			// Note: if neither 'serial' nor 'hostname' is defined and type is 'zxnext', this will create an error
 		}
 		if (launchCfg.zxnext.timeout === undefined) {
 			launchCfg.zxnext.timeout = 5;	// Seconds
 		}
-		// Note: the port is defaulted only for a socket connection, so that a
-		// leftover 'port' next to a 'serial' can still be recognized below.
-		if (launchCfg.zxnext.hostname !== undefined && launchCfg.zxnext.port === undefined) {
-			launchCfg.zxnext.port = 11000;
+		// The presence of 'serial' selects the serial connection, otherwise a
+		// socket connection is used.
+		// Note: 'hostname' and 'port' are defaulted only for the socket
+		// connection, so that they can still be recognized below if they were
+		// given next to a 'serial'.
+		if (launchCfg.zxnext.serial === undefined) {
+			if (launchCfg.zxnext.hostname === undefined)
+				launchCfg.zxnext.hostname = 'localhost';
+			if (launchCfg.zxnext.port === undefined)
+				launchCfg.zxnext.port = 11000;
 		}
 
 		// sjasmplus
@@ -1225,23 +1231,18 @@ export class Settings {
 			throw Error("'remoteType': Remote type '" + rType + "' does not exist. Allowed are " + allowedTypes.join(', ') + ".");
 		}
 
-		// Check 'serial'/'hostname' if 'zxnext' was selected
+		// Check the transport properties if 'zxnext' was selected
 		if (rType === 'zxnext') {
-			const serial = Settings.launch.zxnext.serial;
-			const hostname = Settings.launch.zxnext.hostname;
-			if (serial === undefined && hostname === undefined) {
-				throw Error("For remoteType 'zxnext' you need to set either the 'zxnext.serial' property for the serial interface or the 'zxnext.hostname' property for a socket connection.");
-			}
-			if (serial !== undefined && hostname !== undefined) {
-				throw Error("For remoteType 'zxnext' you can use either 'zxnext.serial' or 'zxnext.hostname', but not both.");
-			}
 			// Check that the old properties are not used
 			const oldZxnext = Settings.launch.zxnext as any;
 			if (oldZxnext.socketTimeout !== undefined) {
 				throw Error("For 'zxnext' the property 'socketTimeout' is not used anymore. Use 'timeout' instead.");
 			}
-			if (serial !== undefined && Settings.launch.zxnext.port !== undefined) {
-				throw Error("For 'zxnext' the property 'port' is only used together with 'hostname'.");
+			// 'serial' selects the serial connection, so 'hostname' and 'port'
+			// are meaningless next to it.
+			if (Settings.launch.zxnext.serial !== undefined
+				&& (Settings.launch.zxnext.hostname !== undefined || Settings.launch.zxnext.port !== undefined)) {
+				throw Error("For 'zxnext' the properties 'hostname' and 'port' are used for a socket connection only, i.e. without 'serial'.");
 			}
 		}
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -883,7 +883,9 @@ export class Settings {
 		if (launchCfg.zxnext.timeout === undefined) {
 			launchCfg.zxnext.timeout = 5;	// Seconds
 		}
-		if (launchCfg.zxnext.port === undefined) {
+		// Note: the port is defaulted only for a socket connection, so that a
+		// leftover 'port' next to a 'serial' can still be recognized below.
+		if (launchCfg.zxnext.hostname !== undefined && launchCfg.zxnext.port === undefined) {
 			launchCfg.zxnext.port = 11000;
 		}
 
@@ -1233,10 +1235,13 @@ export class Settings {
 			if (serial !== undefined && hostname !== undefined) {
 				throw Error("For remoteType 'zxnext' you can use either 'zxnext.serial' or 'zxnext.hostname', but not both.");
 			}
-			// Check that the old property is not used
+			// Check that the old properties are not used
 			const oldZxnext = Settings.launch.zxnext as any;
 			if (oldZxnext.socketTimeout !== undefined) {
 				throw Error("For 'zxnext' the property 'socketTimeout' is not used anymore. Use 'timeout' instead.");
+			}
+			if (serial !== undefined && Settings.launch.zxnext.port !== undefined) {
+				throw Error("For 'zxnext' the property 'port' is only used together with 'hostname'.");
 			}
 		}
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -155,9 +155,17 @@ export interface MameType {
 
 // Definitions for ZX Next remote type.
 export interface ZxNextSerialType {
-	// The serial usb device.
+	// The serial usb device. Use either 'serial' or 'hostname'.
 	serial: string;	// E.g. "/dev/cu.usbserial-AQ007PCD" on macOS
-	/// The serial timeout in seconds.
+
+	// The hostname/IP address of the ZX Next, if connected via socket
+	// (e.g. the ESP8266 WiFi module). Use either 'serial' or 'hostname'.
+	hostname: string;
+
+	// The port of the ZX Next socket.
+	port: number;
+
+	/// The timeout in seconds.
 	timeout: number;
 }
 
@@ -870,10 +878,13 @@ export class Settings {
 		// zxnext
 		if (!launchCfg.zxnext) {
 			launchCfg.zxnext = {} as ZxNextSerialType;
-			// Note: if 'serial' is undefined and type is 'zxnext', this will create an error
+			// Note: if neither 'serial' nor 'hostname' is defined and type is 'zxnext', this will create an error
 		}
 		if (launchCfg.zxnext.timeout === undefined) {
 			launchCfg.zxnext.timeout = 5;	// Seconds
+		}
+		if (launchCfg.zxnext.port === undefined) {
+			launchCfg.zxnext.port = 11000;
 		}
 
 		// sjasmplus
@@ -1212,15 +1223,20 @@ export class Settings {
 			throw Error("'remoteType': Remote type '" + rType + "' does not exist. Allowed are " + allowedTypes.join(', ') + ".");
 		}
 
-		// Check 'serial' if 'zxnext' was selected
+		// Check 'serial'/'hostname' if 'zxnext' was selected
 		if (rType === 'zxnext') {
-			if (Settings.launch.zxnext.serial === undefined) {
-				throw Error("For remoteType 'zxnext' you need to set the 'zxnext.serial' property for the serial interface.");
+			const serial = Settings.launch.zxnext.serial;
+			const hostname = Settings.launch.zxnext.hostname;
+			if (serial === undefined && hostname === undefined) {
+				throw Error("For remoteType 'zxnext' you need to set either the 'zxnext.serial' property for the serial interface or the 'zxnext.hostname' property for a socket connection.");
 			}
-			// Check that the old properties are not used
+			if (serial !== undefined && hostname !== undefined) {
+				throw Error("For remoteType 'zxnext' you can use either 'zxnext.serial' or 'zxnext.hostname', but not both.");
+			}
+			// Check that the old property is not used
 			const oldZxnext = Settings.launch.zxnext as any;
-			if (oldZxnext.port !== undefined || oldZxnext.hostname !== undefined || oldZxnext.socketTimeout !== undefined) {
-				throw Error("For 'zxnext' the properties 'port', 'hostname' and 'socketTimeout' are not used anymore. Use 'serial' instead.");
+			if (oldZxnext.socketTimeout !== undefined) {
+				throw Error("For 'zxnext' the property 'socketTimeout' is not used anymore. Use 'timeout' instead.");
 			}
 		}
 

--- a/tests/settings.tests.ts
+++ b/tests/settings.tests.ts
@@ -65,7 +65,21 @@ suite('Settings', () => {
 				}, "Should not fail with remoteType=zxnext.");
 			});
 
-			test('hostname obsolete', () => {
+			test('hostname', () => {
+				const cfg: any = {
+					remoteType: 'zxnext',
+					zxnext: {
+						hostname: 'hname'
+					},
+					rootFolder: './tests/data',
+				};
+				Settings.launch = Settings.Init(cfg);
+				assert.doesNotThrow(() => {
+					Settings.CheckSettings();
+				}, "Should not fail with remoteType=zxnext and a hostname.");
+			});
+
+			test('serial and hostname are exclusive', () => {
 				const cfg: any = {
 					remoteType: 'zxnext',
 					zxnext: {
@@ -77,22 +91,7 @@ suite('Settings', () => {
 				Settings.launch = Settings.Init(cfg);
 				assert.throws(() => {
 					Settings.CheckSettings();
-				}, "Should fail with remoteType=zxnext and old parameters used.");
-			});
-
-			test('port obsolete', () => {
-				const cfg: any = {
-					remoteType: 'zxnext',
-					zxnext: {
-						serial: 'COM8',
-						port: 'port'
-					},
-					rootFolder: './tests/data',
-				};
-				Settings.launch = Settings.Init(cfg);
-				assert.throws(() => {
-					Settings.CheckSettings();
-				}, "Should fail with remoteType=zxnext and old parameters used.");
+				}, "Should fail with remoteType=zxnext and both serial and hostname set.");
 			});
 
 			test('socketTimeout obsolete', () => {

--- a/tests/settings.tests.ts
+++ b/tests/settings.tests.ts
@@ -46,9 +46,12 @@ suite('Settings', () => {
 					rootFolder: './tests/data',
 				};
 				Settings.launch = Settings.Init(cfg);
-				assert.throws(() => {
+				assert.doesNotThrow(() => {
 					Settings.CheckSettings();
-				}, "Should fail with remoteType=zxnext and serial not set.");
+				}, "Should not fail with remoteType=zxnext and serial not set.");
+				// Without a 'serial' a socket connection is used
+				assert.strictEqual(Settings.launch.zxnext.hostname, 'localhost');
+				assert.strictEqual(Settings.launch.zxnext.port, 11000);
 			});
 
 			test('serial', () => {
@@ -79,7 +82,7 @@ suite('Settings', () => {
 				}, "Should not fail with remoteType=zxnext and a hostname.");
 			});
 
-			test('serial and hostname are exclusive', () => {
+			test('hostname not used with serial', () => {
 				const cfg: any = {
 					remoteType: 'zxnext',
 					zxnext: {
@@ -94,7 +97,7 @@ suite('Settings', () => {
 				}, "Should fail with remoteType=zxnext and both serial and hostname set.");
 			});
 
-			test('port needs hostname', () => {
+			test('port not used with serial', () => {
 				const cfg: any = {
 					remoteType: 'zxnext',
 					zxnext: {

--- a/tests/settings.tests.ts
+++ b/tests/settings.tests.ts
@@ -94,6 +94,21 @@ suite('Settings', () => {
 				}, "Should fail with remoteType=zxnext and both serial and hostname set.");
 			});
 
+			test('port needs hostname', () => {
+				const cfg: any = {
+					remoteType: 'zxnext',
+					zxnext: {
+						serial: 'COM8',
+						port: 11000
+					},
+					rootFolder: './tests/data',
+				};
+				Settings.launch = Settings.Init(cfg);
+				assert.throws(() => {
+					Settings.CheckSettings();
+				}, "Should fail with remoteType=zxnext and a port next to a serial.");
+			});
+
 			test('socketTimeout obsolete', () => {
 				const cfg: any = {
 					remoteType: 'zxnext',


### PR DESCRIPTION
## Summary

Gives the `zxnext` remote a socket transport again, beside the serial one, so a ZX Next reached over its ESP8266 WiFi module can be debugged with the breakpoint dialect the dezogif stub actually implements.

The problem this solves: over WiFi the only released remote with a configurable hostname is `cspect`, and `CSpectRemote` sends `CMD_ADD_BREAKPOINT` (40) where the dezogif-derived stub implements `CMD_SET_BREAKPOINTS` (13) / `CMD_RESTORE_MEM` (14). The command goes unanswered, DeZog logs "No response received from remote" and carries on, so a breakpoint set in the editor silently never fires.

The transport is chosen from the configuration, as before 2.6.0:

```json
"remoteType": "zxnext",
"zxnext": { "hostname": "192.168.1.42" }
```

`serial` selects the serial connection, `hostname` the socket. Setting both is an error; setting neither is the existing error. `port` defaults to 11000 and `timeout` is shared.

`ZxNextSocketRemote` derives from `ZxNextSerialRemote` and overrides only the transport — `doInitialization`, `disconnect`, `sendBuffer` — borrowing the socket handling from `CSpectRemote`. Everything above it, in particular the set-before-continue / restore-on-break breakpoint handling, is inherited unchanged. `ZxNextSerialLoopback` already derives from `ZxNextSerialRemote` the same way.

Two further differences, both consequences of the transport rather than of the machine, so neither needs a flag or capability negotiation:

- **No MESSAGE_START_BYTE.** It exists because the ZX Next emits zeroes through the serial cable when the joy port is not configured; a socket has no such problem. Hence the one change to `ZxNextSerialRemote`: a `usesMessageStartByte` field, default `true`, guarding the existing swallow loop.
- **CMD_PAUSE is not refused.** Over the cable the joy ports are handed back to the debugged program on continue, which re-points the UART RX line away from the joy port pin, so nothing can be received while the program runs. Through a socket the byte does arrive. Whether the pause then takes effect is up to the program on the ZX Next, which has to notice it — the client no longer decides that on its behalf.

The two settings tests for the properties that became obsolete in 2.6.0 are repurposed rather than dropped: `hostname` is now valid on its own, and setting it together with `serial` is the error.

An alternative shape would be a separate `zxnextsocket` remote type, which cannot disturb existing users at all. This one restores the pre-2.6.0 arrangement instead; happy to switch if you prefer the other.

## Test plan

`npm test` — 900 passing, both on this branch and on main, i.e. no change in count.

Driven against a real ZX Spectrum Next over WiFi (core 03.02.01, ESP8266 at 460800, an enNextMf.rom derived from dezogif) from the Extension Development Host:

- attaches; registers, memory and source view populate
- a `.nex` loads over the socket (CMD_WRITE_BANK)
- **a breakpoint set in the editor is verified and hit; Continue from it hits it again, repeatedly** — i.e. the restore/step-off/re-plant path works, which is the part that was broken under `cspect`
- breakpoint removed, Continue, then Pause returns control
- IM reads `?` rather than a value the stub cannot know, since `Z80RegistersZxNextDecoder` is inherited

**Not tested: the serial path.** I have no USB/serial adapter. The change to `ZxNextSerialRemote` is the one `usesMessageStartByte` term on the existing condition and defaults to the previous behaviour, but it is unexercised and worth a loopback run before this is merged.

Also untested: breakpoints at addresses `checkBreakpoint` refuses, conditions, LOGPOINTs and ASSERTIONs.
